### PR TITLE
feat: HTML šablonovací systém pro sdílené komponenty

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,98 +1,112 @@
 # DGCP website
 
-Web Disc Golf Clubu Praha. Založeno na [Agency](https://startbootstrap.com/template-overviews/agency/) šabloně od Start Bootstrap.
+Web Disc Golf Clubu Praha — [dgcp.cz](https://dgcp.cz)
 
-## Struktura projektu
+---
 
-```
-dgcp-web/
-├── src/                    # ZDROJOVÉ SOUBORY — editujte ZDE
-│   ├── pages/              # Zdrojové stránky (obsah jednotlivých stránek)
-│   │   ├── index.html
-│   │   ├── krouzek.html
-│   │   ├── nase_turnaje.html
-│   │   ├── instrukce_slevy.html
-│   │   ├── seznam_clenu.html
-│   │   ├── navrhni-dres.html
-│   │   └── scitani/        # Stránky návštěvnosti hřišť
-│   └── partials/           # Sdílené komponenty
-│       ├── head.html       # <head> blok (meta tagy, CSS, fonty)
-│       ├── nav.html        # Navigační menu
-│       ├── footer.html     # Patička (sociální sítě, copyright)
-│       └── scripts.html    # JS importy (jQuery, Bootstrap, agency.js)
-├── scss/                   # SCSS styly
-├── css/                    # Zkompilované CSS (generováno z SCSS)
-├── js/                     # JavaScript
-├── img/                    # Obrázky
-├── vendor/                 # Závislosti třetích stran (generováno z node_modules)
-├── index.html              # GENEROVANÉ — needitovat přímo!
-├── krouzek.html            # GENEROVANÉ
-├── ...                     # (další generované HTML soubory)
-└── scitani/                # GENEROVANÉ
-```
+## Editace přes GitHub (bez instalace)
 
-## Jak to funguje
+Pro jednoduché úpravy obsahu stránek nepotřebujete nic instalovat. Stačí webový prohlížeč a účet na GitHubu.
 
-Web používá šablonovací systém `gulp-file-include`. Zdrojové stránky v `src/pages/` obsahují pouze unikátní obsah každé stránky a volání `@@include()` pro sdílené části (navigace, patička atd.). Gulp task `html` zkompiluje šablony a vygeneruje finální HTML soubory v kořenovém adresáři, které se pak zobrazují na webu.
+### Kde najdu soubory k editaci
 
-**HTML soubory v kořenovém adresáři jsou generované — needitujte je přímo!** Při dalším buildu by se vaše změny přepsaly.
+Veškeré stránky webu se nacházejí ve složce [`src/pages/`](https://github.com/dgcpraha/dgcpraha.github.io/tree/master/src/pages):
 
-## Editace webu
+| Soubor | Stránka |
+|--------|---------|
+| `src/pages/index.html` | Hlavní stránka |
+| `src/pages/krouzek.html` | Kroužek discgolfu |
+| `src/pages/nase_turnaje.html` | Pořádané ligy a turnaje |
+| `src/pages/instrukce_slevy.html` | Jak uplatnit slevy u partnerů |
+| `src/pages/seznam_clenu.html` | Seznam členů |
+| `src/pages/navrhni-dres.html` | Soutěž o návrh dresu |
 
-### Úprava obsahu stránky
-Editujte odpovídající soubor v `src/pages/`, např. `src/pages/krouzek.html`.
+Sdílené části webu (navigace, patička) jsou ve složce [`src/partials/`](https://github.com/dgcpraha/dgcpraha.github.io/tree/master/src/partials):
 
-### Úprava navigace, patičky nebo hlavičky
-Editujte soubor v `src/partials/` — změna se automaticky projeví na všech stránkách.
+| Soubor | Co obsahuje |
+|--------|-------------|
+| `src/partials/nav.html` | Navigační menu (zobrazuje se na všech stránkách) |
+| `src/partials/footer.html` | Patička se sociálními sítěmi a copyrightem |
+| `src/partials/head.html` | Hlavička stránky (CSS, fonty) |
+| `src/partials/scripts.html` | Importy JavaScriptu |
 
-### Úprava stylů
-Editujte SCSS soubory ve složce `scss/`.
+### Jak provést úpravu
 
-### Po úpravě
-Spusťte build pro vygenerování finálních souborů:
-```bash
-npx gulp html        # pouze HTML
-npx gulp build       # vše (HTML + CSS + JS + vendor)
-```
+1. Přihlaste se na [GitHub](https://github.com)
+2. Otevřete soubor, který chcete upravit (viz tabulky výše)
+3. Klikněte na ikonku tužky ("Edit this file") vpravo nahoře
+4. Proveďte úpravy v textu — měníte jen obsah mezi HTML tagy, např. text mezi `<p>` a `</p>`
+5. Dole v části "Commit changes" stručně popište, co jste změnili
+6. Zvolte "Create a new branch" a klikněte na "Propose changes"
+7. Na další stránce klikněte "Create pull request"
+8. Požádejte správce, aby změny zkontroloval, spustil build a schválil
 
-Commitněte jak zdrojové soubory (`src/`), tak vygenerované HTML soubory.
+### Důležité
 
-## Editace pro mírně pokročilé (přes GitHub)
+- **Needitujte HTML soubory v kořenovém adresáři** (např. `index.html`, `krouzek.html`) — ty jsou generované a vaše změny by se při dalším buildu přepsaly. Vždy editujte soubory ve složce `src/`.
+- Pokud chcete změnit navigaci nebo patičku, stačí upravit příslušný soubor v `src/partials/` — změna se projeví na všech stránkách najednou.
 
-Pokud chcete upravit pouze obsah jedné stránky:
+---
 
-1. Přihlaste se na GitHub
-2. Otevřete odpovídající soubor ve složce `src/pages/` v repozitáři [dgcpraha/dgcpraha.github.io](https://github.com/dgcpraha/dgcpraha.github.io)
-3. Stiskněte tlačítko "Edit this file" (ikonka tužky)
-4. Proveďte úpravy
-5. Dole v části "Commit changes" stručně popište svoji úpravu
-6. Stiskněte "Propose file change" a poté "Create pull request"
-7. Požádejte někoho ze správců, aby změny potvrdil a spustil build
-
-## Vývoj
+## Lokální vývoj (pro vývojáře)
 
 ### Požadavky
-- Node.js (viz `.nvmrc` pro doporučenou verzi)
-- npm
+
+- [Node.js](https://nodejs.org/) (viz `.nvmrc` pro doporučenou verzi)
+- npm (součást Node.js)
 
 ### Instalace
+
 ```bash
+git clone https://github.com/dgcpraha/dgcpraha.github.io.git
+cd dgcpraha.github.io
 npm install
 ```
 
 ### Vývoj s live reload
+
 ```bash
 npm start
 ```
-Otevře se prohlížeč na `localhost:3000`, který se automaticky obnovuje při změnách.
+
+Otevře se prohlížeč na `localhost:3000`. Při uložení jakéhokoli souboru v `src/`, `scss/` nebo `js/` se stránka automaticky obnoví.
+
+### Struktura projektu
+
+```
+├── src/                    # ZDROJOVÉ SOUBORY — editujte ZDE
+│   ├── pages/              # Obsah jednotlivých stránek
+│   │   ├── index.html
+│   │   ├── krouzek.html
+│   │   ├── nase_turnaje.html
+│   │   └── ...
+│   └── partials/           # Sdílené komponenty (navigace, patička, ...)
+├── scss/                   # Styly (SCSS)
+├── js/                     # JavaScript
+├── img/                    # Obrázky
+├── index.html              # Generované — needitovat!
+├── krouzek.html            # Generované — needitovat!
+└── ...
+```
+
+Web používá šablonovací systém [gulp-file-include](https://www.npmjs.com/package/gulp-file-include). Stránky v `src/pages/` obsahují pouze unikátní obsah a volání `@@include()` pro sdílené části. Gulp task `html` z nich vygeneruje finální HTML soubory v kořenovém adresáři.
 
 ### Gulp tasky
-- `gulp` — výchozí task, buildne vše
-- `gulp watch` — BrowserSync s live reload
-- `gulp html` — zkompiluje HTML šablony ze `src/` do kořenového adresáře
-- `gulp css` — zkompiluje SCSS do CSS a minifikuje
-- `gulp js` — minifikuje JS
-- `gulp vendor` — zkopíruje závislosti z node_modules do vendor/
+
+| Příkaz | Co dělá |
+|--------|---------|
+| `npx gulp` | Buildne vše (HTML + CSS + JS + vendor) |
+| `npx gulp html` | Zkompiluje HTML šablony ze `src/` |
+| `npx gulp css` | Zkompiluje SCSS do CSS a minifikuje |
+| `npx gulp js` | Minifikuje JavaScript |
+| `npx gulp watch` | BrowserSync s live reload |
+
+### Workflow pro změny
+
+1. Upravte soubory v `src/pages/` nebo `src/partials/`
+2. Spusťte `npx gulp html` (nebo `npx gulp` pro kompletní build)
+3. Commitněte jak zdrojové soubory (`src/`), tak vygenerované HTML
+4. Pushněte a vytvořte pull request
 
 ## Licence
 

--- a/README.md
+++ b/README.md
@@ -1,68 +1,99 @@
-# Editace pro mírně pokročilé
-
-- pokud nejsi přihlášen na GitHub, přihlaš se 
-- otevři soubor `index.html` v repozitáři `dgcpraha/dgcpraha.github.io` [-LINK-](https://github.com/dgcpraha/dgcpraha.github.io/blob/master/index.html)
-- stiskni tlačítko "Edit this file" (ikonka tužky vpravo nad částí s kódem) 
-- uprav co je potřeba
-- dole v části "Commit changes" stručně popiš v čem spočívá tvoje úprava
-- stiskni tlačítko "Propose file change"
-- na další stránce klikni "Create pull request"
-- požádej někoho ze správců aby změny potvrdil
-- vyčkej až je potvrdí + cca 2 minuty a bude to online
-
-
-
 # DGCP website
 
-Based on [Agency](https://startbootstrap.com/template-overviews/agency/) theme
+Web Disc Golf Clubu Praha. Založeno na [Agency](https://startbootstrap.com/template-overviews/agency/) šabloně od Start Bootstrap.
 
-## Status
+## Struktura projektu
 
-[![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://raw.githubusercontent.com/BlackrockDigital/startbootstrap-agency/master/LICENSE)
-[![npm version](https://img.shields.io/npm/v/startbootstrap-agency.svg)](https://www.npmjs.com/package/startbootstrap-agency)
-[![Build Status](https://travis-ci.org/BlackrockDigital/startbootstrap-agency.svg?branch=master)](https://travis-ci.org/BlackrockDigital/startbootstrap-agency)
-[![dependencies Status](https://david-dm.org/BlackrockDigital/startbootstrap-agency/status.svg)](https://david-dm.org/BlackrockDigital/startbootstrap-agency)
-[![devDependencies Status](https://david-dm.org/BlackrockDigital/startbootstrap-agency/dev-status.svg)](https://david-dm.org/BlackrockDigital/startbootstrap-agency?type=dev)
+```
+dgcp-web/
+├── src/                    # ZDROJOVÉ SOUBORY — editujte ZDE
+│   ├── pages/              # Zdrojové stránky (obsah jednotlivých stránek)
+│   │   ├── index.html
+│   │   ├── krouzek.html
+│   │   ├── nase_turnaje.html
+│   │   ├── instrukce_slevy.html
+│   │   ├── seznam_clenu.html
+│   │   ├── navrhni-dres.html
+│   │   └── scitani/        # Stránky návštěvnosti hřišť
+│   └── partials/           # Sdílené komponenty
+│       ├── head.html       # <head> blok (meta tagy, CSS, fonty)
+│       ├── nav.html        # Navigační menu
+│       ├── footer.html     # Patička (sociální sítě, copyright)
+│       └── scripts.html    # JS importy (jQuery, Bootstrap, agency.js)
+├── scss/                   # SCSS styly
+├── css/                    # Zkompilované CSS (generováno z SCSS)
+├── js/                     # JavaScript
+├── img/                    # Obrázky
+├── vendor/                 # Závislosti třetích stran (generováno z node_modules)
+├── index.html              # GENEROVANÉ — needitovat přímo!
+├── krouzek.html            # GENEROVANÉ
+├── ...                     # (další generované HTML soubory)
+└── scitani/                # GENEROVANÉ
+```
 
-## Usage
+## Jak to funguje
 
-### Basic Usage
+Web používá šablonovací systém `gulp-file-include`. Zdrojové stránky v `src/pages/` obsahují pouze unikátní obsah každé stránky a volání `@@include()` pro sdílené části (navigace, patička atd.). Gulp task `html` zkompiluje šablony a vygeneruje finální HTML soubory v kořenovém adresáři, které se pak zobrazují na webu.
 
-After downloading, simply edit the HTML and CSS files included with the template in your favorite text editor to make changes. These are the only files you need to worry about, you can ignore everything else! To preview the changes you make to the code, you can open the `index.html` file in your web browser.
+**HTML soubory v kořenovém adresáři jsou generované — needitujte je přímo!** Při dalším buildu by se vaše změny přepsaly.
 
-### Advanced Usage
+## Editace webu
 
-After installation, run `npm install` and then run `npm start` which will open up a preview of the template in your default browser, watch for changes to core template files, and live reload the browser when changes are saved. You can view the `gulpfile.js` to see which tasks are included with the dev environment.
+### Úprava obsahu stránky
+Editujte odpovídající soubor v `src/pages/`, např. `src/pages/krouzek.html`.
 
-#### Gulp Tasks
+### Úprava navigace, patičky nebo hlavičky
+Editujte soubor v `src/partials/` — změna se automaticky projeví na všech stránkách.
 
-- `gulp` the default task that builds everything
-- `gulp watch` browserSync opens the project in your default browser and live reloads when changes are made
-- `gulp css` compiles SCSS files into CSS and minifies the compiled CSS
-- `gulp js` minifies the themes JS file
-- `gulp vendor` copies dependencies from node_modules to the vendor directory
+### Úprava stylů
+Editujte SCSS soubory ve složce `scss/`.
 
-You must have npm installed globally in order to use this build environment.
+### Po úpravě
+Spusťte build pro vygenerování finálních souborů:
+```bash
+npx gulp html        # pouze HTML
+npx gulp build       # vše (HTML + CSS + JS + vendor)
+```
 
-## Bugs and Issues
+Commitněte jak zdrojové soubory (`src/`), tak vygenerované HTML soubory.
 
-Have a bug or an issue with this template? [Open a new issue](https://github.com/BlackrockDigital/startbootstrap-agency/issues) here on GitHub or leave a comment on the [template overview page at Start Bootstrap](http://startbootstrap.com/template-overviews/agency/).
+## Editace pro mírně pokročilé (přes GitHub)
 
-## About
+Pokud chcete upravit pouze obsah jedné stránky:
 
-Start Bootstrap is an open source library of free Bootstrap templates and themes. All of the free templates and themes on Start Bootstrap are released under the MIT license, which means you can use them for any purpose, even for commercial projects.
+1. Přihlaste se na GitHub
+2. Otevřete odpovídající soubor ve složce `src/pages/` v repozitáři [dgcpraha/dgcpraha.github.io](https://github.com/dgcpraha/dgcpraha.github.io)
+3. Stiskněte tlačítko "Edit this file" (ikonka tužky)
+4. Proveďte úpravy
+5. Dole v části "Commit changes" stručně popište svoji úpravu
+6. Stiskněte "Propose file change" a poté "Create pull request"
+7. Požádejte někoho ze správců, aby změny potvrdil a spustil build
 
-* https://startbootstrap.com
-* https://twitter.com/SBootstrap
+## Vývoj
 
-Start Bootstrap was created by and is maintained by **[David Miller](http://davidmiller.io/)**, Owner of [Blackrock Digital](http://blackrockdigital.io/).
+### Požadavky
+- Node.js (viz `.nvmrc` pro doporučenou verzi)
+- npm
 
-* http://davidmiller.io
-* https://twitter.com/davidmillerskt
-* https://github.com/davidtmiller
+### Instalace
+```bash
+npm install
+```
 
-Start Bootstrap is based on the [Bootstrap](http://getbootstrap.com/) framework created by [Mark Otto](https://twitter.com/mdo) and [Jacob Thorton](https://twitter.com/fat).
+### Vývoj s live reload
+```bash
+npm start
+```
+Otevře se prohlížeč na `localhost:3000`, který se automaticky obnovuje při změnách.
 
-## Copyright and License
+### Gulp tasky
+- `gulp` — výchozí task, buildne vše
+- `gulp watch` — BrowserSync s live reload
+- `gulp html` — zkompiluje HTML šablony ze `src/` do kořenového adresáře
+- `gulp css` — zkompiluje SCSS do CSS a minifikuje
+- `gulp js` — minifikuje JS
+- `gulp vendor` — zkopíruje závislosti z node_modules do vendor/
 
-Copyright 2013-2019 Blackrock Digital LLC. Code released under the [MIT](https://github.com/BlackrockDigital/startbootstrap-agency/blob/gh-pages/LICENSE) license.
+## Licence
+
+[MIT](https://github.com/BlackrockDigital/startbootstrap-agency/blob/gh-pages/LICENSE)

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,6 +12,7 @@ const plumber = require("gulp-plumber");
 const rename = require("gulp-rename");
 const sass = require("gulp-sass")(require("sass"));
 const uglify = require("gulp-uglify");
+const fileinclude = require("gulp-file-include");
 
 // Load package.json for banner
 const pkg = require('./package.json');
@@ -115,21 +116,33 @@ function js() {
     .pipe(browsersync.stream());
 }
 
+// HTML task - compile templates from src/pages to root
+function html() {
+  return gulp
+    .src(['./src/pages/**/*.html'])
+    .pipe(fileinclude({
+      prefix: '@@',
+      basepath: './src/'
+    }))
+    .pipe(gulp.dest('./'));
+}
+
 // Watch files
 function watchFiles() {
   gulp.watch("./scss/**/*", css);
   gulp.watch(["./js/**/*", "!./js/**/*.min.js"], js);
-  gulp.watch("./**/*.html", browserSyncReload);
+  gulp.watch("./src/**/*.html", gulp.series(html, browserSyncReload));
 }
 
 // Define complex tasks
 const vendor = gulp.series(clean, modules);
-const build = gulp.series(vendor, gulp.parallel(css, js));
+const build = gulp.series(vendor, gulp.parallel(css, js, html));
 const watch = gulp.series(build, gulp.parallel(watchFiles, browserSync));
 
 // Export tasks
 exports.css = css;
 exports.js = js;
+exports.html = html;
 exports.clean = clean;
 exports.vendor = vendor;
 exports.build = build;

--- a/instrukce_slevy.html
+++ b/instrukce_slevy.html
@@ -9,7 +9,6 @@
 </style>
 
 <head>
-
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="">
@@ -18,10 +17,10 @@
     <title>DGC Praha – Disc Golf Club Praha</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link href="./vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- Custom fonts for this template -->
-    <link href="vendor/fontawesome-free/css/all.min.css" rel="stylesheet" type="text/css">
+    <link href="./vendor/fontawesome-free/css/all.min.css" rel="stylesheet" type="text/css">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
     <link href='https://fonts.googleapis.com/css?family=Kaushan+Script' rel='stylesheet' type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic,700italic' rel='stylesheet'
@@ -29,7 +28,8 @@
     <link href='https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700' rel='stylesheet' type='text/css'>
 
     <!-- Custom styles for this template -->
-    <link href="css/agency.min.css" rel="stylesheet">
+    <link href="./css/agency.min.css" rel="stylesheet">
+
 </head>
 
 <body id="page-top">
@@ -37,8 +37,8 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top navbar-shrink always-shrink" id="mainNav">
         <div class="container">
-            <a class="navbar-brand js-scroll-trigger" href="index.html">
-                <img class="mx-auto" src="img/logo/dgcp-logo-final-white.png" alt="" style="height: 3em;">
+            <a class="navbar-brand js-scroll-trigger" href="./index.html">
+                <img class="mx-auto" src="./img/logo/dgcp-logo-final-white.png" alt="" style="height: 3em;">
             </a>
             <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
                 data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false"
@@ -49,30 +49,31 @@
             <div class="collapse navbar-collapse" id="navbarResponsive">
                 <ul class="navbar-nav text-uppercase ml-auto">
                     <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="index.html#aktuality">Aktuality</a>
+                        <a class="nav-link js-scroll-trigger" href="./index.html#aktuality">Aktuality</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="index.html#onas">O nás</a>
+                        <a class="nav-link js-scroll-trigger" href="./index.html#onas">O nás</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="index.html#clenstvi">Členství</a>
+                        <a class="nav-link js-scroll-trigger" href="./index.html#clenstvi">Členství</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="index.html#treninky">Tréninky</a>
+                        <a class="nav-link js-scroll-trigger" href="./index.html#treninky">Tréninky</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="nase_turnaje.html">Akce</a>
+                        <a class="nav-link" href="./nase_turnaje.html">Akce</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="index.html#partneri">Partneři</a>
+                        <a class="nav-link js-scroll-trigger" href="./index.html#partneri">Partneři</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="index.html#kontakt">Kontakt</a>
+                        <a class="nav-link js-scroll-trigger" href="./index.html#kontakt">Kontakt</a>
                     </li>
                 </ul>
             </div>
         </div>
     </nav>
+
 
     <section class="page-section" id="slevy">
         <div class="container">
@@ -139,7 +140,7 @@
                     </ul>
                 </div>
                 <div class="col-md-6">
-                    <span class="copyright">© <span id="year"></span> - Discgolf club Praha (DGC Praha), z. s.</span>
+                    <span class="copyright">&copy; <span id="year"></span> - Discgolf club Praha (DGC Praha), z. s.</span>
                 </div>
             </div>
 
@@ -151,15 +152,15 @@
     </script>
 
     <!-- Bootstrap core JavaScript -->
-    <script src="vendor/jquery/jquery.min.js"></script>
-    <script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+    <script src="./vendor/jquery/jquery.min.js"></script>
+    <script src="./vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
 
     <!-- Plugin JavaScript -->
-    <script src="vendor/jquery-easing/jquery.easing.min.js"></script>
-
+    <script src="./vendor/jquery-easing/jquery.easing.min.js"></script>
 
     <!-- Custom scripts for this template -->
-    <script src="js/agency.min.js"></script>
+    <script src="./js/agency.min.js"></script>
+
 
 </body>
 

--- a/krouzek.html
+++ b/krouzek.html
@@ -10,7 +10,6 @@
 </style>
 
 <head>
-
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="">
@@ -19,10 +18,10 @@
     <title>DGC Praha – Disc Golf Club Praha</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link href="./vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- Custom fonts for this template -->
-    <link href="vendor/fontawesome-free/css/all.min.css" rel="stylesheet" type="text/css">
+    <link href="./vendor/fontawesome-free/css/all.min.css" rel="stylesheet" type="text/css">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
     <link href='https://fonts.googleapis.com/css?family=Kaushan+Script' rel='stylesheet' type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic,700italic' rel='stylesheet'
@@ -30,7 +29,8 @@
     <link href='https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700' rel='stylesheet' type='text/css'>
 
     <!-- Custom styles for this template -->
-    <link href="css/agency.min.css" rel="stylesheet">
+    <link href="./css/agency.min.css" rel="stylesheet">
+
 </head>
 
 <body id="page-top">
@@ -38,8 +38,8 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top navbar-shrink always-shrink" id="mainNav">
         <div class="container">
-            <a class="navbar-brand js-scroll-trigger" href="index.html">
-                <img class="mx-auto" src="img/logo/dgcp-logo-final-white.png" alt="" style="height: 3em;">
+            <a class="navbar-brand js-scroll-trigger" href="./index.html">
+                <img class="mx-auto" src="./img/logo/dgcp-logo-final-white.png" alt="" style="height: 3em;">
             </a>
             <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
                 data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false"
@@ -50,30 +50,31 @@
             <div class="collapse navbar-collapse" id="navbarResponsive">
                 <ul class="navbar-nav text-uppercase ml-auto">
                     <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="index.html#aktuality">Aktuality</a>
+                        <a class="nav-link js-scroll-trigger" href="./index.html#aktuality">Aktuality</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="index.html#onas">O nás</a>
+                        <a class="nav-link js-scroll-trigger" href="./index.html#onas">O nás</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="index.html#clenstvi">Členství</a>
+                        <a class="nav-link js-scroll-trigger" href="./index.html#clenstvi">Členství</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="index.html#treninky">Tréninky</a>
+                        <a class="nav-link js-scroll-trigger" href="./index.html#treninky">Tréninky</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="nase_turnaje.html">Akce</a>
+                        <a class="nav-link" href="./nase_turnaje.html">Akce</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="index.html#partneri">Partneři</a>
+                        <a class="nav-link js-scroll-trigger" href="./index.html#partneri">Partneři</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="index.html#kontakt">Kontakt</a>
+                        <a class="nav-link js-scroll-trigger" href="./index.html#kontakt">Kontakt</a>
                     </li>
                 </ul>
             </div>
         </div>
     </nav>
+
 
     <section class="page-section" id="krouzek">
         <div class="container mb-5">
@@ -91,7 +92,7 @@
                 Pokud počasí dovolí, tak se taky společně podíváme na hřiště. Disky budou na kroužku k dispozici, takže si na začátek nemusíš pořizovat svoje.
             </p>
             <p>
-                Přihlášku na kroužek vyplňte <a href="https://forms.gle/Yg6VneCgMFbTrn9t5" target="_blank">ZDE</a>. Je potřeba souhlas zákonného zástpuce. 
+                Přihlášku na kroužek vyplňte <a href="https://forms.gle/Yg6VneCgMFbTrn9t5" target="_blank">ZDE</a>. Je potřeba souhlas zákonného zástpuce.
                 Případné dotazy ke kroužku směřujte na <a href="mailto:marketa@dgcp.cz">marketa@dgcp.cz</a>.
             </p>
             <div class="mx-auto text-center">
@@ -101,8 +102,8 @@
                 </a>
             </div>
             <p>
-                Letáček ke stažení ve formátu pdf <a href="https://dgcp.cz/img/letacek_krouzek.pdf" target="_blank">ZDE</a> 
-                a ve formátu jpg <a href="https://dgcp.cz/img/letacek_krouzek.jpg" target="_blank">ZDE</a>. 
+                Letáček ke stažení ve formátu pdf <a href="https://dgcp.cz/img/letacek_krouzek.pdf" target="_blank">ZDE</a>
+                a ve formátu jpg <a href="https://dgcp.cz/img/letacek_krouzek.jpg" target="_blank">ZDE</a>.
             </p>
         </div>
         <div class="container mb-5">
@@ -116,7 +117,7 @@
             </div>
         </div>
     </section>
-    <section class="page-section bg-light">        
+    <section class="page-section bg-light">
         <div class="container mb-5">
             <h3 class="section-heading text-uppercase">Partneři kroužku</h3>
             <div class="row text-center">
@@ -167,7 +168,7 @@
                     </ul>
                 </div>
                 <div class="col-md-6">
-                    <span class="copyright">© <span id="year"></span> - Discgolf club Praha (DGC Praha), z. s.</span>
+                    <span class="copyright">&copy; <span id="year"></span> - Discgolf club Praha (DGC Praha), z. s.</span>
                 </div>
             </div>
 
@@ -179,15 +180,15 @@
     </script>
 
     <!-- Bootstrap core JavaScript -->
-    <script src="vendor/jquery/jquery.min.js"></script>
-    <script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+    <script src="./vendor/jquery/jquery.min.js"></script>
+    <script src="./vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
 
     <!-- Plugin JavaScript -->
-    <script src="vendor/jquery-easing/jquery.easing.min.js"></script>
-
+    <script src="./vendor/jquery-easing/jquery.easing.min.js"></script>
 
     <!-- Custom scripts for this template -->
-    <script src="js/agency.min.js"></script>
+    <script src="./js/agency.min.js"></script>
+
 
 </body>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
                 "gulp": "4.0.2",
                 "gulp-autoprefixer": "7.0.0",
                 "gulp-clean-css": "4.2.0",
+                "gulp-file-include": "^2.3.0",
                 "gulp-header": "2.0.9",
                 "gulp-plumber": "^1.2.1",
                 "gulp-rename": "1.4.0",
@@ -2452,6 +2453,12 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/flatnest": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/flatnest/-/flatnest-1.0.1.tgz",
+            "integrity": "sha512-fw6V/6LdrkB/q/mW/8M4PfX9sDUo4k5UZ9vlRlTrsbhDrxbe51puGoGHOmfr5hAczTH/33Q4jzuDnOBerGaIlQ==",
+            "dev": true
+        },
         "node_modules/flush-write-stream": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -3482,6 +3489,60 @@
                 "readable-stream": "2 || 3"
             }
         },
+        "node_modules/gulp-file-include": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/gulp-file-include/-/gulp-file-include-2.3.0.tgz",
+            "integrity": "sha512-OoMq5QtXHYz6hu2dZm1OxravcqrPXGeCNvOtz+8/589zFKcdpKGGvFXz/Aw4hx8pKZqaS+oJusgKDVQ4dCzqSg==",
+            "dev": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-stream": "^2.0.0",
+                "extend": "^3.0.2",
+                "flatnest": "^1.0.0",
+                "json5": "^2.1.3",
+                "plugin-error": "^1.0.1",
+                "through2": "^4.0.2",
+                "vinyl": "^2.2.1"
+            }
+        },
+        "node_modules/gulp-file-include/node_modules/concat-stream": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+            "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+            "dev": true,
+            "engines": [
+                "node >= 6.0"
+            ],
+            "dependencies": {
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^3.0.2",
+                "typedarray": "^0.0.6"
+            }
+        },
+        "node_modules/gulp-file-include/node_modules/readable-stream": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+            "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+            "dev": true,
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/gulp-file-include/node_modules/through2": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+            "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+            "dev": true,
+            "dependencies": {
+                "readable-stream": "3"
+            }
+        },
         "node_modules/gulp-header": {
             "version": "2.0.9",
             "resolved": "https://registry.npmjs.org/gulp-header/-/gulp-header-2.0.9.tgz",
@@ -4274,6 +4335,18 @@
             "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
             "dev": true
         },
+        "node_modules/json5": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "dev": true,
+            "bin": {
+                "json5": "lib/cli.js"
+            },
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/jsonfile": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
@@ -4455,7 +4528,7 @@
         "node_modules/lodash.clonedeep": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-            "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
             "dev": true
         },
         "node_modules/lodash.isfinite": {
@@ -5742,13 +5815,13 @@
             "dev": true
         },
         "node_modules/sass": {
-            "version": "1.97.3",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
-            "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
+            "version": "1.98.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.98.0.tgz",
+            "integrity": "sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==",
             "dev": true,
             "dependencies": {
                 "chokidar": "^4.0.0",
-                "immutable": "^5.0.2",
+                "immutable": "^5.1.5",
                 "source-map-js": ">=0.6.2 <2.0.0"
             },
             "bin": {
@@ -6905,9 +6978,9 @@
             }
         },
         "node_modules/vinyl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-            "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.1.tgz",
+            "integrity": "sha512-LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw==",
             "dev": true,
             "dependencies": {
                 "clone": "^2.1.1",
@@ -8980,6 +9053,12 @@
             "integrity": "sha512-lNaHNVymajmk0OJMBn8fVUAU1BtDeKIqKoVhk4xAALB57aALg6b4W0MfJ/cUE0g9YBXy5XhSlPIpYIJ7HaY/3Q==",
             "dev": true
         },
+        "flatnest": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/flatnest/-/flatnest-1.0.1.tgz",
+            "integrity": "sha512-fw6V/6LdrkB/q/mW/8M4PfX9sDUo4k5UZ9vlRlTrsbhDrxbe51puGoGHOmfr5hAczTH/33Q4jzuDnOBerGaIlQ==",
+            "dev": true
+        },
         "flush-write-stream": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/flush-write-stream/-/flush-write-stream-1.1.1.tgz",
@@ -9862,6 +9941,56 @@
                 }
             }
         },
+        "gulp-file-include": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/gulp-file-include/-/gulp-file-include-2.3.0.tgz",
+            "integrity": "sha512-OoMq5QtXHYz6hu2dZm1OxravcqrPXGeCNvOtz+8/589zFKcdpKGGvFXz/Aw4hx8pKZqaS+oJusgKDVQ4dCzqSg==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "^1.0.0",
+                "concat-stream": "^2.0.0",
+                "extend": "^3.0.2",
+                "flatnest": "^1.0.0",
+                "json5": "^2.1.3",
+                "plugin-error": "^1.0.1",
+                "through2": "^4.0.2",
+                "vinyl": "^2.2.1"
+            },
+            "dependencies": {
+                "concat-stream": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+                    "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+                    "dev": true,
+                    "requires": {
+                        "buffer-from": "^1.0.0",
+                        "inherits": "^2.0.3",
+                        "readable-stream": "^3.0.2",
+                        "typedarray": "^0.0.6"
+                    }
+                },
+                "readable-stream": {
+                    "version": "3.6.2",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+                    "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "through2": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-4.0.2.tgz",
+                    "integrity": "sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "3"
+                    }
+                }
+            }
+        },
         "gulp-header": {
             "version": "2.0.9",
             "resolved": "https://registry.npmjs.org/gulp-header/-/gulp-header-2.0.9.tgz",
@@ -10444,6 +10573,12 @@
             "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
             "dev": true
         },
+        "json5": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+            "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+            "dev": true
+        },
         "jsonfile": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
@@ -10602,7 +10737,7 @@
         "lodash.clonedeep": {
             "version": "4.5.0",
             "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-            "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
             "dev": true
         },
         "lodash.isfinite": {
@@ -11644,14 +11779,14 @@
             "dev": true
         },
         "sass": {
-            "version": "1.97.3",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.97.3.tgz",
-            "integrity": "sha512-fDz1zJpd5GycprAbu4Q2PV/RprsRtKC/0z82z0JLgdytmcq0+ujJbJ/09bPGDxCLkKY3Np5cRAOcWiVkLXJURg==",
+            "version": "1.98.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.98.0.tgz",
+            "integrity": "sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==",
             "dev": true,
             "requires": {
                 "@parcel/watcher": "^2.4.1",
                 "chokidar": "^4.0.0",
-                "immutable": "^5.0.2",
+                "immutable": "^5.1.5",
                 "source-map-js": ">=0.6.2 <2.0.0"
             },
             "dependencies": {
@@ -12613,9 +12748,9 @@
             "dev": true
         },
         "vinyl": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.0.tgz",
-            "integrity": "sha512-MBH+yP0kC/GQ5GwBqrTPTzEfiiLjta7hTtvQtbxBgTeSXsmKQRQecjibMbxIXzVT3Y9KJK+drOz1/k+vsu8Nkg==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-2.2.1.tgz",
+            "integrity": "sha512-LII3bXRFBZLlezoG5FfZVcXflZgWP/4dCwKtxd5ky9+LOtM4CS3bIRQsmR1KMnMW07jpE8fqR2lcxPZ+8sJIcw==",
             "dev": true,
             "requires": {
                 "clone": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "gulp": "4.0.2",
         "gulp-autoprefixer": "7.0.0",
         "gulp-clean-css": "4.2.0",
+        "gulp-file-include": "^2.3.0",
         "gulp-header": "2.0.9",
         "gulp-plumber": "^1.2.1",
         "gulp-rename": "1.4.0",

--- a/scitani/bechovice.html
+++ b/scitani/bechovice.html
@@ -18,54 +18,56 @@
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
     <link href='https://fonts.googleapis.com/css?family=Kaushan+Script' rel='stylesheet' type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic,700italic' rel='stylesheet'
-          type='text/css'>
+        type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700' rel='stylesheet' type='text/css'>
 
     <!-- Custom styles for this template -->
     <link href="../css/agency.min.css" rel="stylesheet">
+
 </head>
 
 <body id="page-top">
 
-<!-- Navigation -->
-<nav class="navbar navbar-expand-lg navbar-dark fixed-top navbar-shrink always-shrink" id="mainNav">
-    <div class="container">
-        <a class="navbar-brand js-scroll-trigger" href="index.html#page-top">
-            <img class="mx-auto" src="../img/logo/dgcp-logo-final-white.png" alt="" style="height: 3em;">
-        </a>
-        <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
+    <!-- Navigation -->
+    <nav class="navbar navbar-expand-lg navbar-dark fixed-top navbar-shrink always-shrink" id="mainNav">
+        <div class="container">
+            <a class="navbar-brand js-scroll-trigger" href="../index.html">
+                <img class="mx-auto" src="../img/logo/dgcp-logo-final-white.png" alt="" style="height: 3em;">
+            </a>
+            <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
                 data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false"
                 aria-label="Toggle navigation">
-            Menu
-            <i class="fas fa-bars"></i>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarResponsive">
-            <ul class="navbar-nav text-uppercase ml-auto">
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#onas">O nás</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#clenstvi">Členství</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#treninky">Tréninky</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../challenge.html#challenge">Klubová challenge</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#partneri">Partneři</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="index.html">Návštěvnost hřišť</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#kontakt">Kontakt</a>
-                </li>
-            </ul>
+                Menu
+                <i class="fas fa-bars"></i>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarResponsive">
+                <ul class="navbar-nav text-uppercase ml-auto">
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#aktuality">Aktuality</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#onas">O nás</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#clenstvi">Členství</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#treninky">Tréninky</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="../nase_turnaje.html">Akce</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#partneri">Partneři</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#kontakt">Kontakt</a>
+                    </li>
+                </ul>
+            </div>
         </div>
-    </div>
-</nav>
+    </nav>
+
 
 <style>
     table {
@@ -88,41 +90,46 @@
 
 </section>
 
-<!-- Footer -->
-<footer class="footer">
-    <div class="container">
-        <div class="row align-items-center">
-            <div class="col-md-6">
-                <ul class="list-inline social-buttons">
-                    <li class="list-inline-item">
-                        <a href="https://www.facebook.com/groups/230785370665041" target="_blank">
-                            <i class="fab fa-facebook-f"></i>
-                        </a>
-                    </li>
-                </ul>
+    <!-- Footer -->
+    <footer class="footer">
+        <div class="container">
+            <div class="row align-items-center">
+                <div class="col-md-6">
+                    <ul class="list-inline social-buttons">
+                        <li class="list-inline-item">
+                            <a href="https://www.facebook.com/profile.php?id=61571287846047" target="_blank">
+                                <i class="fab fa-facebook-f"></i>
+                            </a>
+                        </li>
+                        <li class="list-inline-item">
+                            <a href="https://www.instagram.com/discgolfclubpraha/" target="_blank">
+                                <i class="fab fa-instagram"></i>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+                <div class="col-md-6">
+                    <span class="copyright">&copy; <span id="year"></span> - Discgolf club Praha (DGC Praha), z. s.</span>
+                </div>
             </div>
-            <div class="col-md-6">
-                <span class="copyright">© <span id="year"></span> - Discgolf club Praha (DGC Praha), z. s.</span>
-            </div>
+
         </div>
+    </footer>
 
-    </div>
-</footer>
+    <script>
+        document.getElementById("year").innerHTML = new Date().getFullYear();
+    </script>
 
-<script>
-    document.getElementById("year").innerHTML = new Date().getFullYear();
-</script>
+    <!-- Bootstrap core JavaScript -->
+    <script src="../vendor/jquery/jquery.min.js"></script>
+    <script src="../vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
 
-<!-- Bootstrap core JavaScript -->
-<script src="../vendor/jquery/jquery.min.js"></script>
-<script src="../vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+    <!-- Plugin JavaScript -->
+    <script src="../vendor/jquery-easing/jquery.easing.min.js"></script>
 
-<!-- Plugin JavaScript -->
-<script src="../vendor/jquery-easing/jquery.easing.min.js"></script>
+    <!-- Custom scripts for this template -->
+    <script src="../js/agency.min.js"></script>
 
-
-<!-- Custom scripts for this template -->
-<script src="../js/agency.min.js"></script>
 
 </body>
 </html>

--- a/scitani/chodov.html
+++ b/scitani/chodov.html
@@ -18,54 +18,56 @@
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
     <link href='https://fonts.googleapis.com/css?family=Kaushan+Script' rel='stylesheet' type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic,700italic' rel='stylesheet'
-          type='text/css'>
+        type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700' rel='stylesheet' type='text/css'>
 
     <!-- Custom styles for this template -->
     <link href="../css/agency.min.css" rel="stylesheet">
+
 </head>
 
 <body id="page-top">
 
-<!-- Navigation -->
-<nav class="navbar navbar-expand-lg navbar-dark fixed-top navbar-shrink always-shrink" id="mainNav">
-    <div class="container">
-        <a class="navbar-brand js-scroll-trigger" href="index.html#page-top">
-            <img class="mx-auto" src="../img/logo/dgcp-logo-final-white.png" alt="" style="height: 3em;">
-        </a>
-        <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
+    <!-- Navigation -->
+    <nav class="navbar navbar-expand-lg navbar-dark fixed-top navbar-shrink always-shrink" id="mainNav">
+        <div class="container">
+            <a class="navbar-brand js-scroll-trigger" href="../index.html">
+                <img class="mx-auto" src="../img/logo/dgcp-logo-final-white.png" alt="" style="height: 3em;">
+            </a>
+            <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
                 data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false"
                 aria-label="Toggle navigation">
-            Menu
-            <i class="fas fa-bars"></i>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarResponsive">
-            <ul class="navbar-nav text-uppercase ml-auto">
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#onas">O nás</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#clenstvi">Členství</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#treninky">Tréninky</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../challenge.html#challenge">Klubová challenge</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#partneri">Partneři</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="index.html">Návštěvnost hřišť</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#kontakt">Kontakt</a>
-                </li>
-            </ul>
+                Menu
+                <i class="fas fa-bars"></i>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarResponsive">
+                <ul class="navbar-nav text-uppercase ml-auto">
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#aktuality">Aktuality</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#onas">O nás</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#clenstvi">Členství</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#treninky">Tréninky</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="../nase_turnaje.html">Akce</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#partneri">Partneři</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#kontakt">Kontakt</a>
+                    </li>
+                </ul>
+            </div>
         </div>
-    </div>
-</nav>
+    </nav>
+
 
 <style>
     table {
@@ -88,41 +90,46 @@
 
 </section>
 
-<!-- Footer -->
-<footer class="footer">
-    <div class="container">
-        <div class="row align-items-center">
-            <div class="col-md-6">
-                <ul class="list-inline social-buttons">
-                    <li class="list-inline-item">
-                        <a href="https://www.facebook.com/groups/230785370665041" target="_blank">
-                            <i class="fab fa-facebook-f"></i>
-                        </a>
-                    </li>
-                </ul>
+    <!-- Footer -->
+    <footer class="footer">
+        <div class="container">
+            <div class="row align-items-center">
+                <div class="col-md-6">
+                    <ul class="list-inline social-buttons">
+                        <li class="list-inline-item">
+                            <a href="https://www.facebook.com/profile.php?id=61571287846047" target="_blank">
+                                <i class="fab fa-facebook-f"></i>
+                            </a>
+                        </li>
+                        <li class="list-inline-item">
+                            <a href="https://www.instagram.com/discgolfclubpraha/" target="_blank">
+                                <i class="fab fa-instagram"></i>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+                <div class="col-md-6">
+                    <span class="copyright">&copy; <span id="year"></span> - Discgolf club Praha (DGC Praha), z. s.</span>
+                </div>
             </div>
-            <div class="col-md-6">
-                <span class="copyright">© <span id="year"></span> - Discgolf club Praha (DGC Praha), z. s.</span>
-            </div>
+
         </div>
+    </footer>
 
-    </div>
-</footer>
+    <script>
+        document.getElementById("year").innerHTML = new Date().getFullYear();
+    </script>
 
-<script>
-    document.getElementById("year").innerHTML = new Date().getFullYear();
-</script>
+    <!-- Bootstrap core JavaScript -->
+    <script src="../vendor/jquery/jquery.min.js"></script>
+    <script src="../vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
 
-<!-- Bootstrap core JavaScript -->
-<script src="../vendor/jquery/jquery.min.js"></script>
-<script src="../vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+    <!-- Plugin JavaScript -->
+    <script src="../vendor/jquery-easing/jquery.easing.min.js"></script>
 
-<!-- Plugin JavaScript -->
-<script src="../vendor/jquery-easing/jquery.easing.min.js"></script>
+    <!-- Custom scripts for this template -->
+    <script src="../js/agency.min.js"></script>
 
-
-<!-- Custom scripts for this template -->
-<script src="../js/agency.min.js"></script>
 
 </body>
 </html>

--- a/scitani/index.html
+++ b/scitani/index.html
@@ -17,54 +17,56 @@
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
     <link href='https://fonts.googleapis.com/css?family=Kaushan+Script' rel='stylesheet' type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic,700italic' rel='stylesheet'
-          type='text/css'>
+        type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700' rel='stylesheet' type='text/css'>
 
     <!-- Custom styles for this template -->
     <link href="../css/agency.min.css" rel="stylesheet">
+
 </head>
 
 <body id="page-top">
 
-<!-- Navigation -->
-<nav class="navbar navbar-expand-lg navbar-dark fixed-top navbar-shrink always-shrink" id="mainNav">
-    <div class="container">
-        <a class="navbar-brand js-scroll-trigger" href="index.html#page-top">
-            <img class="mx-auto" src="../img/logo/dgcp-logo-final-white.png" alt="" style="height: 3em;">
-        </a>
-        <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
+    <!-- Navigation -->
+    <nav class="navbar navbar-expand-lg navbar-dark fixed-top navbar-shrink always-shrink" id="mainNav">
+        <div class="container">
+            <a class="navbar-brand js-scroll-trigger" href="../index.html">
+                <img class="mx-auto" src="../img/logo/dgcp-logo-final-white.png" alt="" style="height: 3em;">
+            </a>
+            <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
                 data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false"
                 aria-label="Toggle navigation">
-            Menu
-            <i class="fas fa-bars"></i>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarResponsive">
-            <ul class="navbar-nav text-uppercase ml-auto">
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#onas">O nás</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#clenstvi">Členství</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#treninky">Tréninky</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../challenge.html#challenge">Klubová challenge</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#partneri">Partneři</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="index.html">Návštěvnost hřišť</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#kontakt">Kontakt</a>
-                </li>
-            </ul>
+                Menu
+                <i class="fas fa-bars"></i>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarResponsive">
+                <ul class="navbar-nav text-uppercase ml-auto">
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#aktuality">Aktuality</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#onas">O nás</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#clenstvi">Členství</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#treninky">Tréninky</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="../nase_turnaje.html">Akce</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#partneri">Partneři</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#kontakt">Kontakt</a>
+                    </li>
+                </ul>
+            </div>
         </div>
-    </div>
-</nav>
+    </nav>
+
 
 <style>
     table {
@@ -84,41 +86,46 @@
 
 </section>
 
-<!-- Footer -->
-<footer class="footer">
-    <div class="container">
-        <div class="row align-items-center">
-            <div class="col-md-6">
-                <ul class="list-inline social-buttons">
-                    <li class="list-inline-item">
-                        <a href="https://www.facebook.com/groups/230785370665041" target="_blank">
-                            <i class="fab fa-facebook-f"></i>
-                        </a>
-                    </li>
-                </ul>
+    <!-- Footer -->
+    <footer class="footer">
+        <div class="container">
+            <div class="row align-items-center">
+                <div class="col-md-6">
+                    <ul class="list-inline social-buttons">
+                        <li class="list-inline-item">
+                            <a href="https://www.facebook.com/profile.php?id=61571287846047" target="_blank">
+                                <i class="fab fa-facebook-f"></i>
+                            </a>
+                        </li>
+                        <li class="list-inline-item">
+                            <a href="https://www.instagram.com/discgolfclubpraha/" target="_blank">
+                                <i class="fab fa-instagram"></i>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+                <div class="col-md-6">
+                    <span class="copyright">&copy; <span id="year"></span> - Discgolf club Praha (DGC Praha), z. s.</span>
+                </div>
             </div>
-            <div class="col-md-6">
-                <span class="copyright">© <span id="year"></span> - Discgolf club Praha (DGC Praha), z. s.</span>
-            </div>
+
         </div>
+    </footer>
 
-    </div>
-</footer>
+    <script>
+        document.getElementById("year").innerHTML = new Date().getFullYear();
+    </script>
 
-<script>
-    document.getElementById("year").innerHTML = new Date().getFullYear();
-</script>
+    <!-- Bootstrap core JavaScript -->
+    <script src="../vendor/jquery/jquery.min.js"></script>
+    <script src="../vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
 
-<!-- Bootstrap core JavaScript -->
-<script src="../vendor/jquery/jquery.min.js"></script>
-<script src="../vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+    <!-- Plugin JavaScript -->
+    <script src="../vendor/jquery-easing/jquery.easing.min.js"></script>
 
-<!-- Plugin JavaScript -->
-<script src="../vendor/jquery-easing/jquery.easing.min.js"></script>
+    <!-- Custom scripts for this template -->
+    <script src="../js/agency.min.js"></script>
 
-
-<!-- Custom scripts for this template -->
-<script src="../js/agency.min.js"></script>
 
 </body>
 </html>

--- a/scitani/krejcarek.html
+++ b/scitani/krejcarek.html
@@ -18,54 +18,56 @@
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
     <link href='https://fonts.googleapis.com/css?family=Kaushan+Script' rel='stylesheet' type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic,700italic' rel='stylesheet'
-          type='text/css'>
+        type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700' rel='stylesheet' type='text/css'>
 
     <!-- Custom styles for this template -->
     <link href="../css/agency.min.css" rel="stylesheet">
+
 </head>
 
 <body id="page-top">
 
-<!-- Navigation -->
-<nav class="navbar navbar-expand-lg navbar-dark fixed-top navbar-shrink always-shrink" id="mainNav">
-    <div class="container">
-        <a class="navbar-brand js-scroll-trigger" href="index.html#page-top">
-            <img class="mx-auto" src="../img/logo/dgcp-logo-final-white.png" alt="" style="height: 3em;">
-        </a>
-        <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
+    <!-- Navigation -->
+    <nav class="navbar navbar-expand-lg navbar-dark fixed-top navbar-shrink always-shrink" id="mainNav">
+        <div class="container">
+            <a class="navbar-brand js-scroll-trigger" href="../index.html">
+                <img class="mx-auto" src="../img/logo/dgcp-logo-final-white.png" alt="" style="height: 3em;">
+            </a>
+            <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
                 data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false"
                 aria-label="Toggle navigation">
-            Menu
-            <i class="fas fa-bars"></i>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarResponsive">
-            <ul class="navbar-nav text-uppercase ml-auto">
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#onas">O nás</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#clenstvi">Členství</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#treninky">Tréninky</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../challenge.html#challenge">Klubová challenge</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#partneri">Partneři</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="index.html">Návštěvnost hřišť</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#kontakt">Kontakt</a>
-                </li>
-            </ul>
+                Menu
+                <i class="fas fa-bars"></i>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarResponsive">
+                <ul class="navbar-nav text-uppercase ml-auto">
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#aktuality">Aktuality</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#onas">O nás</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#clenstvi">Členství</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#treninky">Tréninky</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="../nase_turnaje.html">Akce</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#partneri">Partneři</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#kontakt">Kontakt</a>
+                    </li>
+                </ul>
+            </div>
         </div>
-    </div>
-</nav>
+    </nav>
+
 
 <style>
     table {
@@ -88,41 +90,46 @@
 
 </section>
 
-<!-- Footer -->
-<footer class="footer">
-    <div class="container">
-        <div class="row align-items-center">
-            <div class="col-md-6">
-                <ul class="list-inline social-buttons">
-                    <li class="list-inline-item">
-                        <a href="https://www.facebook.com/groups/230785370665041" target="_blank">
-                            <i class="fab fa-facebook-f"></i>
-                        </a>
-                    </li>
-                </ul>
+    <!-- Footer -->
+    <footer class="footer">
+        <div class="container">
+            <div class="row align-items-center">
+                <div class="col-md-6">
+                    <ul class="list-inline social-buttons">
+                        <li class="list-inline-item">
+                            <a href="https://www.facebook.com/profile.php?id=61571287846047" target="_blank">
+                                <i class="fab fa-facebook-f"></i>
+                            </a>
+                        </li>
+                        <li class="list-inline-item">
+                            <a href="https://www.instagram.com/discgolfclubpraha/" target="_blank">
+                                <i class="fab fa-instagram"></i>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+                <div class="col-md-6">
+                    <span class="copyright">&copy; <span id="year"></span> - Discgolf club Praha (DGC Praha), z. s.</span>
+                </div>
             </div>
-            <div class="col-md-6">
-                <span class="copyright">© <span id="year"></span> - Discgolf club Praha (DGC Praha), z. s.</span>
-            </div>
+
         </div>
+    </footer>
 
-    </div>
-</footer>
+    <script>
+        document.getElementById("year").innerHTML = new Date().getFullYear();
+    </script>
 
-<script>
-    document.getElementById("year").innerHTML = new Date().getFullYear();
-</script>
+    <!-- Bootstrap core JavaScript -->
+    <script src="../vendor/jquery/jquery.min.js"></script>
+    <script src="../vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
 
-<!-- Bootstrap core JavaScript -->
-<script src="../vendor/jquery/jquery.min.js"></script>
-<script src="../vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+    <!-- Plugin JavaScript -->
+    <script src="../vendor/jquery-easing/jquery.easing.min.js"></script>
 
-<!-- Plugin JavaScript -->
-<script src="../vendor/jquery-easing/jquery.easing.min.js"></script>
+    <!-- Custom scripts for this template -->
+    <script src="../js/agency.min.js"></script>
 
-
-<!-- Custom scripts for this template -->
-<script src="../js/agency.min.js"></script>
 
 </body>
 </html>

--- a/scitani/ladronka.html
+++ b/scitani/ladronka.html
@@ -18,54 +18,56 @@
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
     <link href='https://fonts.googleapis.com/css?family=Kaushan+Script' rel='stylesheet' type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic,700italic' rel='stylesheet'
-          type='text/css'>
+        type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700' rel='stylesheet' type='text/css'>
 
     <!-- Custom styles for this template -->
     <link href="../css/agency.min.css" rel="stylesheet">
+
 </head>
 
 <body id="page-top">
 
-<!-- Navigation -->
-<nav class="navbar navbar-expand-lg navbar-dark fixed-top navbar-shrink always-shrink" id="mainNav">
-    <div class="container">
-        <a class="navbar-brand js-scroll-trigger" href="index.html#page-top">
-            <img class="mx-auto" src="../img/logo/dgcp-logo-final-white.png" alt="" style="height: 3em;">
-        </a>
-        <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
+    <!-- Navigation -->
+    <nav class="navbar navbar-expand-lg navbar-dark fixed-top navbar-shrink always-shrink" id="mainNav">
+        <div class="container">
+            <a class="navbar-brand js-scroll-trigger" href="../index.html">
+                <img class="mx-auto" src="../img/logo/dgcp-logo-final-white.png" alt="" style="height: 3em;">
+            </a>
+            <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
                 data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false"
                 aria-label="Toggle navigation">
-            Menu
-            <i class="fas fa-bars"></i>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarResponsive">
-            <ul class="navbar-nav text-uppercase ml-auto">
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#onas">O nás</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#clenstvi">Členství</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#treninky">Tréninky</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../challenge.html#challenge">Klubová challenge</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#partneri">Partneři</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="index.html">Návštěvnost hřišť</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#kontakt">Kontakt</a>
-                </li>
-            </ul>
+                Menu
+                <i class="fas fa-bars"></i>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarResponsive">
+                <ul class="navbar-nav text-uppercase ml-auto">
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#aktuality">Aktuality</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#onas">O nás</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#clenstvi">Členství</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#treninky">Tréninky</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="../nase_turnaje.html">Akce</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#partneri">Partneři</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#kontakt">Kontakt</a>
+                    </li>
+                </ul>
+            </div>
         </div>
-    </div>
-</nav>
+    </nav>
+
 
 <style>
     table {
@@ -88,41 +90,46 @@
 
 </section>
 
-<!-- Footer -->
-<footer class="footer">
-    <div class="container">
-        <div class="row align-items-center">
-            <div class="col-md-6">
-                <ul class="list-inline social-buttons">
-                    <li class="list-inline-item">
-                        <a href="https://www.facebook.com/groups/230785370665041" target="_blank">
-                            <i class="fab fa-facebook-f"></i>
-                        </a>
-                    </li>
-                </ul>
+    <!-- Footer -->
+    <footer class="footer">
+        <div class="container">
+            <div class="row align-items-center">
+                <div class="col-md-6">
+                    <ul class="list-inline social-buttons">
+                        <li class="list-inline-item">
+                            <a href="https://www.facebook.com/profile.php?id=61571287846047" target="_blank">
+                                <i class="fab fa-facebook-f"></i>
+                            </a>
+                        </li>
+                        <li class="list-inline-item">
+                            <a href="https://www.instagram.com/discgolfclubpraha/" target="_blank">
+                                <i class="fab fa-instagram"></i>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+                <div class="col-md-6">
+                    <span class="copyright">&copy; <span id="year"></span> - Discgolf club Praha (DGC Praha), z. s.</span>
+                </div>
             </div>
-            <div class="col-md-6">
-                <span class="copyright">© <span id="year"></span> - Discgolf club Praha (DGC Praha), z. s.</span>
-            </div>
+
         </div>
+    </footer>
 
-    </div>
-</footer>
+    <script>
+        document.getElementById("year").innerHTML = new Date().getFullYear();
+    </script>
 
-<script>
-    document.getElementById("year").innerHTML = new Date().getFullYear();
-</script>
+    <!-- Bootstrap core JavaScript -->
+    <script src="../vendor/jquery/jquery.min.js"></script>
+    <script src="../vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
 
-<!-- Bootstrap core JavaScript -->
-<script src="../vendor/jquery/jquery.min.js"></script>
-<script src="../vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+    <!-- Plugin JavaScript -->
+    <script src="../vendor/jquery-easing/jquery.easing.min.js"></script>
 
-<!-- Plugin JavaScript -->
-<script src="../vendor/jquery-easing/jquery.easing.min.js"></script>
+    <!-- Custom scripts for this template -->
+    <script src="../js/agency.min.js"></script>
 
-
-<!-- Custom scripts for this template -->
-<script src="../js/agency.min.js"></script>
 
 </body>
 </html>

--- a/scitani/sterboholy.html
+++ b/scitani/sterboholy.html
@@ -18,54 +18,56 @@
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
     <link href='https://fonts.googleapis.com/css?family=Kaushan+Script' rel='stylesheet' type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic,700italic' rel='stylesheet'
-          type='text/css'>
+        type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700' rel='stylesheet' type='text/css'>
 
     <!-- Custom styles for this template -->
     <link href="../css/agency.min.css" rel="stylesheet">
+
 </head>
 
 <body id="page-top">
 
-<!-- Navigation -->
-<nav class="navbar navbar-expand-lg navbar-dark fixed-top navbar-shrink always-shrink" id="mainNav">
-    <div class="container">
-        <a class="navbar-brand js-scroll-trigger" href="index.html#page-top">
-            <img class="mx-auto" src="../img/logo/dgcp-logo-final-white.png" alt="" style="height: 3em;">
-        </a>
-        <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
+    <!-- Navigation -->
+    <nav class="navbar navbar-expand-lg navbar-dark fixed-top navbar-shrink always-shrink" id="mainNav">
+        <div class="container">
+            <a class="navbar-brand js-scroll-trigger" href="../index.html">
+                <img class="mx-auto" src="../img/logo/dgcp-logo-final-white.png" alt="" style="height: 3em;">
+            </a>
+            <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
                 data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false"
                 aria-label="Toggle navigation">
-            Menu
-            <i class="fas fa-bars"></i>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarResponsive">
-            <ul class="navbar-nav text-uppercase ml-auto">
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#onas">O nás</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#clenstvi">Členství</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#treninky">Tréninky</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../challenge.html#challenge">Klubová challenge</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#partneri">Partneři</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="index.html">Návštěvnost hřišť</a>
-                </li>
-                <li class="nav-item">
-                    <a class="nav-link js-scroll-trigger" href="../index.html#kontakt">Kontakt</a>
-                </li>
-            </ul>
+                Menu
+                <i class="fas fa-bars"></i>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarResponsive">
+                <ul class="navbar-nav text-uppercase ml-auto">
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#aktuality">Aktuality</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#onas">O nás</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#clenstvi">Členství</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#treninky">Tréninky</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="../nase_turnaje.html">Akce</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#partneri">Partneři</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="../index.html#kontakt">Kontakt</a>
+                    </li>
+                </ul>
+            </div>
         </div>
-    </div>
-</nav>
+    </nav>
+
 
 <style>
     table {
@@ -88,41 +90,46 @@
 
 </section>
 
-<!-- Footer -->
-<footer class="footer">
-    <div class="container">
-        <div class="row align-items-center">
-            <div class="col-md-6">
-                <ul class="list-inline social-buttons">
-                    <li class="list-inline-item">
-                        <a href="https://www.facebook.com/groups/230785370665041" target="_blank">
-                            <i class="fab fa-facebook-f"></i>
-                        </a>
-                    </li>
-                </ul>
+    <!-- Footer -->
+    <footer class="footer">
+        <div class="container">
+            <div class="row align-items-center">
+                <div class="col-md-6">
+                    <ul class="list-inline social-buttons">
+                        <li class="list-inline-item">
+                            <a href="https://www.facebook.com/profile.php?id=61571287846047" target="_blank">
+                                <i class="fab fa-facebook-f"></i>
+                            </a>
+                        </li>
+                        <li class="list-inline-item">
+                            <a href="https://www.instagram.com/discgolfclubpraha/" target="_blank">
+                                <i class="fab fa-instagram"></i>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+                <div class="col-md-6">
+                    <span class="copyright">&copy; <span id="year"></span> - Discgolf club Praha (DGC Praha), z. s.</span>
+                </div>
             </div>
-            <div class="col-md-6">
-                <span class="copyright">© <span id="year"></span> - Discgolf club Praha (DGC Praha), z. s.</span>
-            </div>
+
         </div>
+    </footer>
 
-    </div>
-</footer>
+    <script>
+        document.getElementById("year").innerHTML = new Date().getFullYear();
+    </script>
 
-<script>
-    document.getElementById("year").innerHTML = new Date().getFullYear();
-</script>
+    <!-- Bootstrap core JavaScript -->
+    <script src="../vendor/jquery/jquery.min.js"></script>
+    <script src="../vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
 
-<!-- Bootstrap core JavaScript -->
-<script src="../vendor/jquery/jquery.min.js"></script>
-<script src="../vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+    <!-- Plugin JavaScript -->
+    <script src="../vendor/jquery-easing/jquery.easing.min.js"></script>
 
-<!-- Plugin JavaScript -->
-<script src="../vendor/jquery-easing/jquery.easing.min.js"></script>
+    <!-- Custom scripts for this template -->
+    <script src="../js/agency.min.js"></script>
 
-
-<!-- Custom scripts for this template -->
-<script src="../js/agency.min.js"></script>
 
 </body>
 </html>

--- a/seznam_clenu.html
+++ b/seznam_clenu.html
@@ -9,7 +9,6 @@
 </style>
 
 <head>
-
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="description" content="">
@@ -18,10 +17,10 @@
     <title>DGC Praha – Disc Golf Club Praha</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+    <link href="./vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
 
     <!-- Custom fonts for this template -->
-    <link href="vendor/fontawesome-free/css/all.min.css" rel="stylesheet" type="text/css">
+    <link href="./vendor/fontawesome-free/css/all.min.css" rel="stylesheet" type="text/css">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
     <link href='https://fonts.googleapis.com/css?family=Kaushan+Script' rel='stylesheet' type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic,700italic' rel='stylesheet'
@@ -29,7 +28,8 @@
     <link href='https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700' rel='stylesheet' type='text/css'>
 
     <!-- Custom styles for this template -->
-    <link href="css/agency.min.css" rel="stylesheet">
+    <link href="./css/agency.min.css" rel="stylesheet">
+
 
     <script>
         function includeHTML() {
@@ -99,8 +99,8 @@
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-dark fixed-top navbar-shrink always-shrink" id="mainNav">
         <div class="container">
-            <a class="navbar-brand js-scroll-trigger" href="index.html">
-                <img class="mx-auto" src="img/logo/dgcp-logo-final-white.png" alt="" style="height: 3em;">
+            <a class="navbar-brand js-scroll-trigger" href="./index.html">
+                <img class="mx-auto" src="./img/logo/dgcp-logo-final-white.png" alt="" style="height: 3em;">
             </a>
             <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
                 data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false"
@@ -111,30 +111,31 @@
             <div class="collapse navbar-collapse" id="navbarResponsive">
                 <ul class="navbar-nav text-uppercase ml-auto">
                     <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="index.html#aktuality">Aktuality</a>
+                        <a class="nav-link js-scroll-trigger" href="./index.html#aktuality">Aktuality</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="index.html#onas">O nás</a>
+                        <a class="nav-link js-scroll-trigger" href="./index.html#onas">O nás</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="index.html#clenstvi">Členství</a>
+                        <a class="nav-link js-scroll-trigger" href="./index.html#clenstvi">Členství</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="index.html#treninky">Tréninky</a>
+                        <a class="nav-link js-scroll-trigger" href="./index.html#treninky">Tréninky</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link" href="nase_turnaje.html">Akce</a>
+                        <a class="nav-link" href="./nase_turnaje.html">Akce</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="index.html#partneri">Partneři</a>
+                        <a class="nav-link js-scroll-trigger" href="./index.html#partneri">Partneři</a>
                     </li>
                     <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="index.html#kontakt">Kontakt</a>
+                        <a class="nav-link js-scroll-trigger" href="./index.html#kontakt">Kontakt</a>
                     </li>
                 </ul>
             </div>
         </div>
     </nav>
+
 
     <!-- Services -->
     <section class="page-section" id="seznam">
@@ -153,7 +154,6 @@
     <script>
         includeHTML();
     </script>
-
 
     <!-- Footer -->
     <footer class="footer">
@@ -174,7 +174,7 @@
                     </ul>
                 </div>
                 <div class="col-md-6">
-                    <span class="copyright">© <span id="year"></span> - Discgolf club Praha (DGC Praha), z. s.</span>
+                    <span class="copyright">&copy; <span id="year"></span> - Discgolf club Praha (DGC Praha), z. s.</span>
                 </div>
             </div>
 
@@ -186,15 +186,15 @@
     </script>
 
     <!-- Bootstrap core JavaScript -->
-    <script src="vendor/jquery/jquery.min.js"></script>
-    <script src="vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+    <script src="./vendor/jquery/jquery.min.js"></script>
+    <script src="./vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
 
     <!-- Plugin JavaScript -->
-    <script src="vendor/jquery-easing/jquery.easing.min.js"></script>
-
+    <script src="./vendor/jquery-easing/jquery.easing.min.js"></script>
 
     <!-- Custom scripts for this template -->
-    <script src="js/agency.min.js"></script>
+    <script src="./js/agency.min.js"></script>
+
 
 </body>
 

--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -37,71 +37,12 @@
 </style>
 
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="description" content="">
-    <meta name="author" content="">
-
-    <title>DGC Praha – Disc Golf Club Praha</title>
-
-    <!-- Bootstrap core CSS -->
-    <link href="./vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
-
-    <!-- Custom fonts for this template -->
-    <link href="./vendor/fontawesome-free/css/all.min.css" rel="stylesheet" type="text/css">
-    <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
-    <link href='https://fonts.googleapis.com/css?family=Kaushan+Script' rel='stylesheet' type='text/css'>
-    <link href='https://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic,700italic' rel='stylesheet'
-        type='text/css'>
-    <link href='https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700' rel='stylesheet' type='text/css'>
-
-    <!-- Custom styles for this template -->
-    <link href="./css/agency.min.css" rel="stylesheet">
-
+@@include('partials/head.html', {"title": "DGC Praha – Disc Golf Club Praha", "basePath": "."})
 </head>
 
 <body id="page-top">
 
-    <!-- Navigation -->
-    <nav class="navbar navbar-expand-lg navbar-dark fixed-top navbar-shrink always-shrink" id="mainNav">
-        <div class="container">
-            <a class="navbar-brand js-scroll-trigger" href="./index.html">
-                <img class="mx-auto" src="./img/logo/dgcp-logo-final-white.png" alt="" style="height: 3em;">
-            </a>
-            <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
-                data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false"
-                aria-label="Toggle navigation">
-                Menu
-                <i class="fas fa-bars"></i>
-            </button>
-            <div class="collapse navbar-collapse" id="navbarResponsive">
-                <ul class="navbar-nav text-uppercase ml-auto">
-                    <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="./index.html#aktuality">Aktuality</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="./index.html#onas">O nás</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="./index.html#clenstvi">Členství</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="./index.html#treninky">Tréninky</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="./nase_turnaje.html">Akce</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="./index.html#partneri">Partneři</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="./index.html#kontakt">Kontakt</a>
-                    </li>
-                </ul>
-            </div>
-        </div>
-    </nav>
-
+@@include('partials/nav.html', {"basePath": "."})
 
     <!-- Header -->
     <header class="masthead">
@@ -661,46 +602,8 @@
         </div>
     </section>
 
-    <!-- Footer -->
-    <footer class="footer">
-        <div class="container">
-            <div class="row align-items-center">
-                <div class="col-md-6">
-                    <ul class="list-inline social-buttons">
-                        <li class="list-inline-item">
-                            <a href="https://www.facebook.com/profile.php?id=61571287846047" target="_blank">
-                                <i class="fab fa-facebook-f"></i>
-                            </a>
-                        </li>
-                        <li class="list-inline-item">
-                            <a href="https://www.instagram.com/discgolfclubpraha/" target="_blank">
-                                <i class="fab fa-instagram"></i>
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-                <div class="col-md-6">
-                    <span class="copyright">&copy; <span id="year"></span> - Discgolf club Praha (DGC Praha), z. s.</span>
-                </div>
-            </div>
-
-        </div>
-    </footer>
-
-    <script>
-        document.getElementById("year").innerHTML = new Date().getFullYear();
-    </script>
-
-    <!-- Bootstrap core JavaScript -->
-    <script src="./vendor/jquery/jquery.min.js"></script>
-    <script src="./vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
-
-    <!-- Plugin JavaScript -->
-    <script src="./vendor/jquery-easing/jquery.easing.min.js"></script>
-
-    <!-- Custom scripts for this template -->
-    <script src="./js/agency.min.js"></script>
-
+@@include('partials/footer.html')
+@@include('partials/scripts.html', {"basePath": "."})
 
     <script>
         $.getJSON('https://spreadsheets.google.com/feeds/cells/1ap5UaQN-kFYGVCTo4MhQb1b_mJ-HTbdFAox_srUtwIs/1/public/full?alt=json', function (data) {

--- a/src/pages/instrukce_slevy.html
+++ b/src/pages/instrukce_slevy.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<style>
+    table {
+        margin-left: auto !important;
+        margin-right: auto !important;
+    }
+</style>
+
+<head>
+@@include('partials/head.html', {"title": "DGC Praha – Disc Golf Club Praha", "basePath": "."})
+</head>
+
+<body id="page-top">
+
+@@include('partials/nav.html', {"basePath": "."})
+
+    <section class="page-section" id="slevy">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-12 text-center">
+                    <h2 class="section-heading text-uppercase">Jak uplatnit slevy u klubových partnerů</h2>
+                </div>
+            </div>
+        </div>
+        <div class="container mb-5" id="ultimo">
+            <h3 class="section-heading text-uppercase">Ultimo.cz</h3>
+            <p>
+                10% sleva v internetovém i kamenném obchodě Ultimo na všechny disky a další slevy na ostatní sortiment.
+                Speciální nabídky, přednostní nákupy a další speciální akce prostřednictvím emailového newsletteru.
+            </p>
+            <p>
+                Pro aktivaci slevy si stačí založit zákaznický účet na www.ultimo.cz podle <a
+                    href="https://www.ultimo.cz/novinky/nakupuj-za-klubove-ceny/">tohoto návodu</a>. Při nákupu v
+                kamenné prodejně je pro uplatnění slevy potřeba předložit klubový tag.
+            </p>
+        </div>
+        <div class="container mb-5" id="discsport">
+            <h3 class="section-heading text-uppercase">Discsport.eu</h3>
+            <p>
+                V současnosti máme Silver členství, což nás opravňuje k nákupům se slevou 1.00 €/disk (na každý
+                jednotlivý disk).
+                Nevztahuje se na sady ani jiné zboží, pouze disky!
+                Pokud budeme mít registrovaných alespoň 25 členů, kteří učiní alespoň 50 objednávek (celkem) za rok,
+                dosáhneme pro další rok na "zlato", což je 1.50 €/disk. Jinak setrváme na Silver.
+            </p>
+            <p>
+                Co pro to udělat?
+            </p>
+            <p>
+                Vytvořit si účet na DISCSPORT.EU a nahlásit své jméno a email použitý při registraci správci klubu -
+                vojtechak@gmail.com.
+            </p>
+            <p>
+                Po přidání si zkontrolujte, zda máte ve svém účtu správně nastavený klub, a pokud ne, tak to opravte.
+                V případě problémů kontaktujte správce.
+            </p>
+            <p>
+                Sleva se uplatní automaticky při Checkoutu na základě porovnání emailové adresy.
+            </p>
+        </div>
+    </section>
+
+@@include('partials/footer.html')
+@@include('partials/scripts.html', {"basePath": "."})
+
+</body>
+
+</html>

--- a/src/pages/krouzek.html
+++ b/src/pages/krouzek.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<style>
+    .button-margin{
+        margin-left: 10px;
+        margin-right: 10px;
+        margin-bottom: 30px;
+    }
+</style>
+
+<head>
+@@include('partials/head.html', {"title": "DGC Praha – Disc Golf Club Praha", "basePath": "."})
+</head>
+
+<body id="page-top">
+
+@@include('partials/nav.html', {"basePath": "."})
+
+    <section class="page-section" id="krouzek">
+        <div class="container mb-5">
+            <div class="col-lg-12 text-center">
+                <h2 class="section-heading text-uppercase">Kroužek discgolfu</h2>
+            </div>
+            <h3 class="section-heading text-uppercase">Informace na školní rok 2025/2026</h3>
+            <p>
+                Nový discgolfový kroužek pod záštitou DGCP probíhá v pondělí od 15:00 do 16:00 v tělocvičně TJ Sokol Praha Košíře. První kroužek proběhne 6. října.
+                Cena kroužku je 1.500 Kč za pololetí.
+            </p>
+            <p>
+                Chceš se naučit házet diskem jako Paul McBeth? Pak se k nám přidej na nový discgolfový kroužek pod záštitou Pražského discgolfového klubu.
+                Projdeme si úplné základy techniky hodů, které budeš na hřišti potřebovat a postupně budeme ladit detaily, aby disky poslouchaly a lítaly daleko.
+                Pokud počasí dovolí, tak se taky společně podíváme na hřiště. Disky budou na kroužku k dispozici, takže si na začátek nemusíš pořizovat svoje.
+            </p>
+            <p>
+                Přihlášku na kroužek vyplňte <a href="https://forms.gle/Yg6VneCgMFbTrn9t5" target="_blank">ZDE</a>. Je potřeba souhlas zákonného zástpuce.
+                Případné dotazy ke kroužku směřujte na <a href="mailto:marketa@dgcp.cz">marketa@dgcp.cz</a>.
+            </p>
+            <div class="mx-auto text-center">
+                <a class="btn btn-xl btn-primary mt-3 button-margin" href="https://forms.gle/Yg6VneCgMFbTrn9t5" target="_blank">
+                    <i class="fa fa-address-card"></i>
+                    Přihláška na kroužek
+                </a>
+            </div>
+            <p>
+                Letáček ke stažení ve formátu pdf <a href="https://dgcp.cz/img/letacek_krouzek.pdf" target="_blank">ZDE</a>
+                a ve formátu jpg <a href="https://dgcp.cz/img/letacek_krouzek.jpg" target="_blank">ZDE</a>.
+            </p>
+        </div>
+        <div class="container mb-5">
+            <div class="row">
+                <div class="text-center col-md-6 noverflow">
+                    <iframe style="border: 1px solid #555;" src="https://mapy.com/s/dovurojugo" width="500" height="333"frameborder="0"></iframe>
+                </div>
+                <div class="text-center col-md-6">
+                    <img src="img/letacek_krouzek.jpg" alt="Letáček kroužek" style="width: 100%; border: 1px solid #555;">
+                </div>
+            </div>
+        </div>
+    </section>
+    <section class="page-section bg-light">
+        <div class="container mb-5">
+            <h3 class="section-heading text-uppercase">Partneři kroužku</h3>
+            <div class="row text-center">
+                <div class="col-md-4">
+                    <div class="portfolio-item">
+                        <div class="portfolio-caption">
+                            <a class="portfolio-link" href="https://www.ultimo.cz" target="_blank">
+                                <img class="img-fluid" src="img/partners/ultimo_logo.png" style="max-height: 100px;" alt="Ultimo.cz">
+                            </a>
+                            <p class="portfolio-caption">
+                                Obchod s discgolfovým vybavením s kamenou prodejnou na Letné.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-md-4">
+                    <div class="portfolio-item">
+                        <div class="portfolio-caption">
+                            <a class="portfolio-link" href="https://dgcp.cz" target="_blank">
+                                <img class="img-fluid" src="img/logo/dgcp-logo-final-black.png" style="max-height: 100px;" alt="DGCP">
+                            </a>
+                            <p class="portfolio-caption">
+                                Největší pražský discgolfový klub, který pořádá řadu turnajů v Praze a okolí.
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </section>
+
+@@include('partials/footer.html')
+@@include('partials/scripts.html', {"basePath": "."})
+
+</body>
+
+</html>

--- a/src/pages/nase_turnaje.html
+++ b/src/pages/nase_turnaje.html
@@ -2,27 +2,7 @@
 <html lang="cs">
 
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="description" content="">
-    <meta name="author" content="">
-
-    <title>DGC Praha – Disc Golf Club Praha</title>
-
-    <!-- Bootstrap core CSS -->
-    <link href="./vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
-
-    <!-- Custom fonts for this template -->
-    <link href="./vendor/fontawesome-free/css/all.min.css" rel="stylesheet" type="text/css">
-    <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
-    <link href='https://fonts.googleapis.com/css?family=Kaushan+Script' rel='stylesheet' type='text/css'>
-    <link href='https://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic,700italic' rel='stylesheet'
-        type='text/css'>
-    <link href='https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700' rel='stylesheet' type='text/css'>
-
-    <!-- Custom styles for this template -->
-    <link href="./css/agency.min.css" rel="stylesheet">
-
+@@include('partials/head.html', {"title": "DGC Praha – Disc Golf Club Praha", "basePath": "."})
 
     <style>
         .noverflow {
@@ -49,46 +29,7 @@
 
 <body id="page-top">
 
-    <!-- Navigation -->
-    <nav class="navbar navbar-expand-lg navbar-dark fixed-top navbar-shrink always-shrink" id="mainNav">
-        <div class="container">
-            <a class="navbar-brand js-scroll-trigger" href="./index.html">
-                <img class="mx-auto" src="./img/logo/dgcp-logo-final-white.png" alt="" style="height: 3em;">
-            </a>
-            <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
-                data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false"
-                aria-label="Toggle navigation">
-                Menu
-                <i class="fas fa-bars"></i>
-            </button>
-            <div class="collapse navbar-collapse" id="navbarResponsive">
-                <ul class="navbar-nav text-uppercase ml-auto">
-                    <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="./index.html#aktuality">Aktuality</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="./index.html#onas">O nás</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="./index.html#clenstvi">Členství</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="./index.html#treninky">Tréninky</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="./nase_turnaje.html">Akce</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="./index.html#partneri">Partneři</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="./index.html#kontakt">Kontakt</a>
-                    </li>
-                </ul>
-            </div>
-        </div>
-    </nav>
-
+@@include('partials/nav.html', {"basePath": "."})
 
     <section class="page-section" id="ligy" style="padding-top: 140px;">
         <div class="container">
@@ -217,46 +158,8 @@
         </div>
     </section>
 
-    <!-- Footer -->
-    <footer class="footer">
-        <div class="container">
-            <div class="row align-items-center">
-                <div class="col-md-6">
-                    <ul class="list-inline social-buttons">
-                        <li class="list-inline-item">
-                            <a href="https://www.facebook.com/profile.php?id=61571287846047" target="_blank">
-                                <i class="fab fa-facebook-f"></i>
-                            </a>
-                        </li>
-                        <li class="list-inline-item">
-                            <a href="https://www.instagram.com/discgolfclubpraha/" target="_blank">
-                                <i class="fab fa-instagram"></i>
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-                <div class="col-md-6">
-                    <span class="copyright">&copy; <span id="year"></span> - Discgolf club Praha (DGC Praha), z. s.</span>
-                </div>
-            </div>
-
-        </div>
-    </footer>
-
-    <script>
-        document.getElementById("year").innerHTML = new Date().getFullYear();
-    </script>
-
-    <!-- Bootstrap core JavaScript -->
-    <script src="./vendor/jquery/jquery.min.js"></script>
-    <script src="./vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
-
-    <!-- Plugin JavaScript -->
-    <script src="./vendor/jquery-easing/jquery.easing.min.js"></script>
-
-    <!-- Custom scripts for this template -->
-    <script src="./js/agency.min.js"></script>
-
+@@include('partials/footer.html')
+@@include('partials/scripts.html', {"basePath": "."})
 
 </body>
 

--- a/src/pages/navrhni-dres.html
+++ b/src/pages/navrhni-dres.html
@@ -13,71 +13,12 @@
 </style>
 
 <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="description" content="">
-    <meta name="author" content="">
-
-    <title>DGC Praha – Disc Golf Club Praha</title>
-
-    <!-- Bootstrap core CSS -->
-    <link href="./vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
-
-    <!-- Custom fonts for this template -->
-    <link href="./vendor/fontawesome-free/css/all.min.css" rel="stylesheet" type="text/css">
-    <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
-    <link href='https://fonts.googleapis.com/css?family=Kaushan+Script' rel='stylesheet' type='text/css'>
-    <link href='https://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic,700italic' rel='stylesheet'
-        type='text/css'>
-    <link href='https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700' rel='stylesheet' type='text/css'>
-
-    <!-- Custom styles for this template -->
-    <link href="./css/agency.min.css" rel="stylesheet">
-
+@@include('partials/head.html', {"title": "DGC Praha – Disc Golf Club Praha", "basePath": "."})
 </head>
 
 <body id="page-top">
 
-    <!-- Navigation -->
-    <nav class="navbar navbar-expand-lg navbar-dark fixed-top navbar-shrink always-shrink" id="mainNav">
-        <div class="container">
-            <a class="navbar-brand js-scroll-trigger" href="./index.html">
-                <img class="mx-auto" src="./img/logo/dgcp-logo-final-white.png" alt="" style="height: 3em;">
-            </a>
-            <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
-                data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false"
-                aria-label="Toggle navigation">
-                Menu
-                <i class="fas fa-bars"></i>
-            </button>
-            <div class="collapse navbar-collapse" id="navbarResponsive">
-                <ul class="navbar-nav text-uppercase ml-auto">
-                    <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="./index.html#aktuality">Aktuality</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="./index.html#onas">O nás</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="./index.html#clenstvi">Členství</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="./index.html#treninky">Tréninky</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link" href="./nase_turnaje.html">Akce</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="./index.html#partneri">Partneři</a>
-                    </li>
-                    <li class="nav-item">
-                        <a class="nav-link js-scroll-trigger" href="./index.html#kontakt">Kontakt</a>
-                    </li>
-                </ul>
-            </div>
-        </div>
-    </nav>
-
+@@include('partials/nav.html', {"basePath": "."})
 
     <section class="page-section" id="ligy">
         <div class="container">
@@ -194,46 +135,8 @@
         </div>
     </section>
 
-    <!-- Footer -->
-    <footer class="footer">
-        <div class="container">
-            <div class="row align-items-center">
-                <div class="col-md-6">
-                    <ul class="list-inline social-buttons">
-                        <li class="list-inline-item">
-                            <a href="https://www.facebook.com/profile.php?id=61571287846047" target="_blank">
-                                <i class="fab fa-facebook-f"></i>
-                            </a>
-                        </li>
-                        <li class="list-inline-item">
-                            <a href="https://www.instagram.com/discgolfclubpraha/" target="_blank">
-                                <i class="fab fa-instagram"></i>
-                            </a>
-                        </li>
-                    </ul>
-                </div>
-                <div class="col-md-6">
-                    <span class="copyright">&copy; <span id="year"></span> - Discgolf club Praha (DGC Praha), z. s.</span>
-                </div>
-            </div>
-
-        </div>
-    </footer>
-
-    <script>
-        document.getElementById("year").innerHTML = new Date().getFullYear();
-    </script>
-
-    <!-- Bootstrap core JavaScript -->
-    <script src="./vendor/jquery/jquery.min.js"></script>
-    <script src="./vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
-
-    <!-- Plugin JavaScript -->
-    <script src="./vendor/jquery-easing/jquery.easing.min.js"></script>
-
-    <!-- Custom scripts for this template -->
-    <script src="./js/agency.min.js"></script>
-
+@@include('partials/footer.html')
+@@include('partials/scripts.html', {"basePath": "."})
 
 </body>
 

--- a/src/pages/scitani/bechovice.html
+++ b/src/pages/scitani/bechovice.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta http-equiv="refresh" content="0; url=https://docs.google.com/forms/d/e/1FAIpQLSfY-BmWxXuRzISWb_sTAd1z8dnF7o2WV7G0Ogs9Ex1a4eibyQ/viewform" />
+@@include('partials/head.html', {"title": "DGC Praha – Disc Golf Club Praha", "basePath": ".."})
+</head>
+
+<body id="page-top">
+
+@@include('partials/nav.html', {"basePath": ".."})
+
+<style>
+    table {
+        margin-left: auto !important;
+        margin-right: auto !important;
+    }
+</style>
+
+<section class="page-section" id="slevy">
+    <div class="container">
+        <h2 class="section-heading text-uppercase">Návštěvnost pražských discgolfových hřišť - Běchovice</h2>
+        <div class="text-center">
+            <p>Pokud nedojde k automatickému přesměrování na formulář, použijte tlačítko níže</p>
+            <a class="btn btn-lg btn-primary mt-3" href="https://docs.google.com/forms/d/e/1FAIpQLSfY-BmWxXuRzISWb_sTAd1z8dnF7o2WV7G0Ogs9Ex1a4eibyQ/viewform" >
+                <i class="fa fa-user-plus"></i>
+                Vyplnit
+            </a>
+        </div>
+    </div>
+
+</section>
+
+@@include('partials/footer.html')
+@@include('partials/scripts.html', {"basePath": ".."})
+
+</body>
+</html>

--- a/src/pages/scitani/chodov.html
+++ b/src/pages/scitani/chodov.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta http-equiv="refresh" content="0; url=https://docs.google.com/forms/d/e/1FAIpQLScKOnGHp2LLy6l2OybM3XIAyas5F4TsBop0t4S2fIhyyyalOg/viewform" />
+@@include('partials/head.html', {"title": "DGC Praha – Disc Golf Club Praha", "basePath": ".."})
+</head>
+
+<body id="page-top">
+
+@@include('partials/nav.html', {"basePath": ".."})
+
+<style>
+    table {
+        margin-left: auto !important;
+        margin-right: auto !important;
+    }
+</style>
+
+<section class="page-section" id="slevy">
+    <div class="container">
+        <h2 class="section-heading text-uppercase">Návštěvnost pražských discgolfových hřišť - Chodov</h2>
+        <div class="text-center">
+            <p>Pokud nedojde k automatickému přesměrování na formulář, použijte tlačítko níže</p>
+            <a class="btn btn-lg btn-primary mt-3" href="https://docs.google.com/forms/d/e/1FAIpQLScKOnGHp2LLy6l2OybM3XIAyas5F4TsBop0t4S2fIhyyyalOg/viewform" >
+                <i class="fa fa-user-plus"></i>
+                Vyplnit
+            </a>
+        </div>
+    </div>
+
+</section>
+
+@@include('partials/footer.html')
+@@include('partials/scripts.html', {"basePath": ".."})
+
+</body>
+</html>

--- a/src/pages/scitani/index.html
+++ b/src/pages/scitani/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+@@include('partials/head.html', {"title": "DGC Praha – Disc Golf Club Praha - Návštěvnost hřišť", "basePath": ".."})
+</head>
+
+<body id="page-top">
+
+@@include('partials/nav.html', {"basePath": ".."})
+
+<style>
+    table {
+        margin-left: auto !important;
+        margin-right: auto !important;
+    }
+</style>
+
+<section class="page-section" id="slevy">
+    <div class="container">
+        <h2 class="section-heading text-uppercase">Návštěvnost pražských discgolfových hřišť</h2>
+        <p>Na teesignu první jamky každého z pražských hřišť jsme umístili instrukce s odkazem na vyplnění formuláře, kam se může nahlásit každá hrající skupina. Chceme tak zjistit, kolik kde hraje hráčů a kdy.</p>
+        <p>Jakmile sesbíráme reprezentativní vzorek dat, výsledky zde zveřejníme.</p>
+    </div>
+    <div class="container text-center">
+    </div>
+
+</section>
+
+@@include('partials/footer.html')
+@@include('partials/scripts.html', {"basePath": ".."})
+
+</body>
+</html>

--- a/src/pages/scitani/krejcarek.html
+++ b/src/pages/scitani/krejcarek.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta http-equiv="refresh" content="0; url=https://docs.google.com/forms/d/e/1FAIpQLScy99EOuPXrxcokE55PUFncaY7iSO6AwSIHMMo7L-kR16mDDg/viewform" />
+@@include('partials/head.html', {"title": "DGC Praha – Disc Golf Club Praha", "basePath": ".."})
+</head>
+
+<body id="page-top">
+
+@@include('partials/nav.html', {"basePath": ".."})
+
+<style>
+    table {
+        margin-left: auto !important;
+        margin-right: auto !important;
+    }
+</style>
+
+<section class="page-section" id="slevy">
+    <div class="container">
+        <h2 class="section-heading text-uppercase">Návštěvnost pražských discgolfových hřišť - Krejcárek</h2>
+        <div class="text-center">
+            <p>Pokud nedojde k automatickému přesměrování na formulář, použijte tlačítko níže</p>
+            <a class="btn btn-lg btn-primary mt-3" href="https://docs.google.com/forms/d/e/1FAIpQLScy99EOuPXrxcokE55PUFncaY7iSO6AwSIHMMo7L-kR16mDDg/viewform" >
+                <i class="fa fa-user-plus"></i>
+                Vyplnit
+            </a>
+        </div>
+    </div>
+
+</section>
+
+@@include('partials/footer.html')
+@@include('partials/scripts.html', {"basePath": ".."})
+
+</body>
+</html>

--- a/src/pages/scitani/ladronka.html
+++ b/src/pages/scitani/ladronka.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta http-equiv="refresh" content="0; url=https://docs.google.com/forms/d/e/1FAIpQLSfQ8EueTA7T4I4IQ3AUEHVnVAD8QwEUqR9oT7n5XGo7tvNXrg/viewform" />
+@@include('partials/head.html', {"title": "DGC Praha – Disc Golf Club Praha", "basePath": ".."})
+</head>
+
+<body id="page-top">
+
+@@include('partials/nav.html', {"basePath": ".."})
+
+<style>
+    table {
+        margin-left: auto !important;
+        margin-right: auto !important;
+    }
+</style>
+
+<section class="page-section" id="slevy">
+    <div class="container">
+        <h2 class="section-heading text-uppercase">Návštěvnost pražských discgolfových hřišť - Ladronka</h2>
+        <div class="text-center">
+            <p>Pokud nedojde k automatickému přesměrování na formulář, použijte tlačítko níže</p>
+            <a class="btn btn-lg btn-primary mt-3" href="https://docs.google.com/forms/d/e/1FAIpQLSfQ8EueTA7T4I4IQ3AUEHVnVAD8QwEUqR9oT7n5XGo7tvNXrg/viewform" >
+                <i class="fa fa-user-plus"></i>
+                Vyplnit
+            </a>
+        </div>
+    </div>
+
+</section>
+
+@@include('partials/footer.html')
+@@include('partials/scripts.html', {"basePath": ".."})
+
+</body>
+</html>

--- a/src/pages/scitani/sterboholy.html
+++ b/src/pages/scitani/sterboholy.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta http-equiv="refresh" content="0; url=https://docs.google.com/forms/d/e/1FAIpQLSdiMUHPzwEt5x0eMktLLJrXRrTX4pO96ofxAwO3GsCXBM4bUw/viewform" />
+@@include('partials/head.html', {"title": "DGC Praha – Disc Golf Club Praha", "basePath": ".."})
+</head>
+
+<body id="page-top">
+
+@@include('partials/nav.html', {"basePath": ".."})
+
+<style>
+    table {
+        margin-left: auto !important;
+        margin-right: auto !important;
+    }
+</style>
+
+<section class="page-section" id="slevy">
+    <div class="container">
+        <h2 class="section-heading text-uppercase">Návštěvnost pražských discgolfových hřišť - Štěrboholy</h2>
+        <div class="text-center">
+            <p>Pokud nedojde k automatickému přesměrování na formulář, použijte tlačítko níže</p>
+            <a class="btn btn-lg btn-primary mt-3" href="https://docs.google.com/forms/d/e/1FAIpQLSdiMUHPzwEt5x0eMktLLJrXRrTX4pO96ofxAwO3GsCXBM4bUw/viewform" >
+                <i class="fa fa-user-plus"></i>
+                Vyplnit
+            </a>
+        </div>
+    </div>
+
+</section>
+
+@@include('partials/footer.html')
+@@include('partials/scripts.html', {"basePath": ".."})
+
+</body>
+</html>

--- a/src/pages/seznam_clenu.html
+++ b/src/pages/seznam_clenu.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<style>
+    table {
+        margin-left: auto !important;
+        margin-right: auto !important;
+    }
+</style>
+
+<head>
+@@include('partials/head.html', {"title": "DGC Praha – Disc Golf Club Praha", "basePath": "."})
+
+    <script>
+        function includeHTML() {
+            var z, i, elmnt, file, xhttp;
+            /* Loop through a collection of all HTML elements: */
+            z = document.getElementsByTagName("*");
+            for (i = 0; i < z.length; i++) {
+                elmnt = z[i];
+                /*search for elements with a certain atrribute:*/
+                file = elmnt.getAttribute("dgcp-include-html");
+                if (file) {
+                    /* Make an HTTP request using the attribute value as the file name: */
+                    xhttp = new XMLHttpRequest();
+                    xhttp.onreadystatechange = function () {
+                        if (this.readyState == 4) {
+                            if (this.status == 200) {
+                                elmnt.innerHTML = this.responseText;
+                                nextThingsToDo()
+                            }
+                            if (this.status == 404) {
+                                elmnt.innerHTML = "Page not found.";
+                            }
+                            /* Remove the attribute, and call this function once more: */
+                            elmnt.removeAttribute("dgcp-include-html");
+                            includeHTML();
+                        }
+                    }
+                    xhttp.open("GET", file, true);
+                    xhttp.send();
+                    /* Exit the function: */
+                    return;
+                }
+            }
+        }
+
+        function nextThingsToDo() {
+            scrollToAnchor("seznam");
+            colorActiveMembers();
+        }
+
+        function scrollToAnchor(anchor) {
+            let element_to_scroll_to = document.getElementById(anchor);
+            element_to_scroll_to.scrollIntoView();
+        }
+
+        function colorActiveMembers() {
+            ap = document.getElementsByTagName('td')
+            for (i = 0; i < ap.length; i++) {
+                a = ap[i];
+                if (a.innerText == "Aktivní") {
+                    a.style.backgroundColor = "#c4ffc4";
+                } else if (a.innerText.toLowerCase() == "bronze") {
+                    a.style.backgroundColor = "#f6b26b";
+                } else if (a.innerText.toLowerCase() == "silver") {
+                    a.style.backgroundColor = "#cccccc";
+                } else if (a.innerText.toLowerCase() == "gold") {
+                    a.style.backgroundColor = "#ffd700";
+                }
+            }
+        }
+    </script>
+
+</head>
+
+<body id="page-top">
+
+@@include('partials/nav.html', {"basePath": "."})
+
+    <!-- Services -->
+    <section class="page-section" id="seznam">
+        <div class="container">
+            <div class="row">
+                <div class="col-lg-12 text-center">
+                    <h2 class="section-heading text-uppercase">Seznam členů</h2>
+                </div>
+            </div>
+            <div class="row mx-auto"
+                dgcp-include-html="https://docs.google.com/spreadsheets/d/1dXTJ62G1-yoLsRPmrL4SbG7Nv02zlnrxAeMyzFb5ets/gviz/tq?tqx=out:html&tq&gid=1275437132">
+            </div>
+        </div>
+    </section>
+
+    <script>
+        includeHTML();
+    </script>
+
+@@include('partials/footer.html')
+@@include('partials/scripts.html', {"basePath": "."})
+
+</body>
+
+</html>

--- a/src/partials/footer.html
+++ b/src/partials/footer.html
@@ -1,0 +1,29 @@
+    <!-- Footer -->
+    <footer class="footer">
+        <div class="container">
+            <div class="row align-items-center">
+                <div class="col-md-6">
+                    <ul class="list-inline social-buttons">
+                        <li class="list-inline-item">
+                            <a href="https://www.facebook.com/profile.php?id=61571287846047" target="_blank">
+                                <i class="fab fa-facebook-f"></i>
+                            </a>
+                        </li>
+                        <li class="list-inline-item">
+                            <a href="https://www.instagram.com/discgolfclubpraha/" target="_blank">
+                                <i class="fab fa-instagram"></i>
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+                <div class="col-md-6">
+                    <span class="copyright">&copy; <span id="year"></span> - Discgolf club Praha (DGC Praha), z. s.</span>
+                </div>
+            </div>
+
+        </div>
+    </footer>
+
+    <script>
+        document.getElementById("year").innerHTML = new Date().getFullYear();
+    </script>

--- a/src/partials/head.html
+++ b/src/partials/head.html
@@ -1,0 +1,20 @@
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <meta name="description" content="">
+    <meta name="author" content="">
+
+    <title>@@title</title>
+
+    <!-- Bootstrap core CSS -->
+    <link href="@@basePath/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- Custom fonts for this template -->
+    <link href="@@basePath/vendor/fontawesome-free/css/all.min.css" rel="stylesheet" type="text/css">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:400,700" rel="stylesheet" type="text/css">
+    <link href='https://fonts.googleapis.com/css?family=Kaushan+Script' rel='stylesheet' type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Droid+Serif:400,700,400italic,700italic' rel='stylesheet'
+        type='text/css'>
+    <link href='https://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700' rel='stylesheet' type='text/css'>
+
+    <!-- Custom styles for this template -->
+    <link href="@@basePath/css/agency.min.css" rel="stylesheet">

--- a/src/partials/nav.html
+++ b/src/partials/nav.html
@@ -1,0 +1,39 @@
+    <!-- Navigation -->
+    <nav class="navbar navbar-expand-lg navbar-dark fixed-top navbar-shrink always-shrink" id="mainNav">
+        <div class="container">
+            <a class="navbar-brand js-scroll-trigger" href="@@basePath/index.html">
+                <img class="mx-auto" src="@@basePath/img/logo/dgcp-logo-final-white.png" alt="" style="height: 3em;">
+            </a>
+            <button class="navbar-toggler navbar-toggler-right" type="button" data-toggle="collapse"
+                data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false"
+                aria-label="Toggle navigation">
+                Menu
+                <i class="fas fa-bars"></i>
+            </button>
+            <div class="collapse navbar-collapse" id="navbarResponsive">
+                <ul class="navbar-nav text-uppercase ml-auto">
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="@@basePath/index.html#aktuality">Aktuality</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="@@basePath/index.html#onas">O nás</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="@@basePath/index.html#clenstvi">Členství</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="@@basePath/index.html#treninky">Tréninky</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="@@basePath/nase_turnaje.html">Akce</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="@@basePath/index.html#partneri">Partneři</a>
+                    </li>
+                    <li class="nav-item">
+                        <a class="nav-link js-scroll-trigger" href="@@basePath/index.html#kontakt">Kontakt</a>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </nav>

--- a/src/partials/scripts.html
+++ b/src/partials/scripts.html
@@ -1,0 +1,9 @@
+    <!-- Bootstrap core JavaScript -->
+    <script src="@@basePath/vendor/jquery/jquery.min.js"></script>
+    <script src="@@basePath/vendor/bootstrap/js/bootstrap.bundle.min.js"></script>
+
+    <!-- Plugin JavaScript -->
+    <script src="@@basePath/vendor/jquery-easing/jquery.easing.min.js"></script>
+
+    <!-- Custom scripts for this template -->
+    <script src="@@basePath/js/agency.min.js"></script>


### PR DESCRIPTION
## Shrnutí

Zavedení šablonovacího systému pomocí `gulp-file-include` pro eliminaci duplicitního HTML kódu napříč všemi stránkami webu.

## Problém

Každá stránka webu (12 HTML souborů) obsahovala kopie identických bloků:
- **Navigace** (~35 řádků) — copy-paste na každé stránce
- **Patička** (~20 řádků) — copy-paste na každé stránce  
- **Hlavička `<head>`** (~20 řádků) — meta tagy, CSS, fonty
- **Importy skriptů** (~10 řádků) — jQuery, Bootstrap, agency.js

Při jakékoli změně navigace (např. přidání položky "Akce") bylo potřeba ručně upravit všech 12 souborů. Stránky v `scitani/` měly navíc zastaralou navigaci (obsahovaly "Klubová challenge" místo "Aktuality"/"Akce") a chyběl jim odkaz na Instagram.

## Řešení

### Nová struktura
```
src/
├── partials/           # Sdílené komponenty (editujte ZDE)
│   ├── head.html       # <head> blok — přijímá @@title, @@basePath
│   ├── nav.html        # Navigace — přijímá @@basePath
│   ├── footer.html     # Patička (sociální sítě, copyright)
│   └── scripts.html    # JS importy — přijímá @@basePath
└── pages/              # Zdrojové stránky (editujte ZDE)
    ├── index.html
    ├── krouzek.html
    ├── nase_turnaje.html
    ├── instrukce_slevy.html
    ├── seznam_clenu.html
    ├── navrhni-dres.html
    └── scitani/
        ├── index.html
        └── [další redirect stránky]
```

### Jak to funguje
- Zdrojové stránky v `src/pages/` obsahují pouze **unikátní obsah** + volání `@@include('partials/nav.html', {"basePath": "."})`
- Gulp task `html` zkompiluje šablony a vygeneruje finální HTML soubory v kořenovém adresáři
- Výstup je stále **čistý statický HTML** — žádný server-side runtime, kompatibilní s GitHub Pages

### Jak používat
- **Editace obsahu stránek**: upravte soubory v `src/pages/`
- **Editace navigace/patičky**: upravte soubory v `src/partials/`
- **Build**: `npx gulp html` (pouze HTML) nebo `npx gulp build` (vše)
- **Vývoj**: `npm start` — sleduje změny a automaticky obnovuje prohlížeč

## Vedlejší opravy
- Stránky v `scitani/` nyní používají **aktuální navigaci** (dříve zastaralá s "Klubová challenge")
- Patička v `scitani/` nyní obsahuje **odkaz na Instagram** (dříve chyběl)

## Technické detaily
- Přidána závislost `gulp-file-include` 
- Nový Gulp task `html` integrovaný do `build` a `watch` pipeline
- Proměnná `@@basePath` řeší relativní cesty (`"."` pro root stránky, `".."` pro scitani/)